### PR TITLE
[npm_package] fails if there is no version field in package.json #42

### DIFF
--- a/lib/comparators/npm_package.js
+++ b/lib/comparators/npm_package.js
@@ -47,7 +47,17 @@ async function getSize(dir) {
 module.exports = {
 
     shouldRun: async function(beforeDir, afterDir) {
-        return fs.existsSync(path.join(afterDir, "package.json"));
+        const pkgJsonPath = path.join(afterDir, "package.json");
+        if (!fs.existsSync(pkgJsonPath)) {
+            return false;
+        }
+
+        const pkgJson = require(pkgJsonPath);
+        if (pkgJson.private || !pkgJson.version) {
+            debug("skpping npm_package: private package or no version in package.json");
+            return false;
+        }
+        return true;
     },
 
     compare: async function(before, after) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/sizewatcher",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/sizewatcher",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Warns if your pull requests introduce large size increases.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Fixes #42.