### PR TITLE
replace stdout-stderr with own solution that keeps order between stdout and stderr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "mocha": "^7.2.0",
         "mock-fs": "^4.13.0",
         "nyc": "^15.1.0",
-        "stdout-stderr": "^0.1.13",
         "supports-color": "^8.1.1"
       }
     },
@@ -4033,19 +4032,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/stdout-stderr": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/stdout-stderr/-/stdout-stderr-0.1.13.tgz",
-      "integrity": "sha512-Xnt9/HHHYfjZ7NeQLvuQDyL1LnbsbddgMFKCuaQKwGCdJm8LnstZIXop+uOY36UR1UXXoHXfMbC1KlVdVd2JLA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -7860,16 +7846,6 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
-      }
-    },
-    "stdout-stderr": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/stdout-stderr/-/stdout-stderr-0.1.13.tgz",
-      "integrity": "sha512-Xnt9/HHHYfjZ7NeQLvuQDyL1LnbsbddgMFKCuaQKwGCdJm8LnstZIXop+uOY36UR1UXXoHXfMbC1KlVdVd2JLA==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.1",
-        "strip-ansi": "^6.0.0"
       }
     },
     "string-width": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "mocha": "^7.2.0",
     "mock-fs": "^4.13.0",
     "nyc": "^15.1.0",
-    "stdout-stderr": "^0.1.13",
     "supports-color": "^8.1.1"
   },
   "dependencies": {

--- a/test/capture-stdout-stderr.js
+++ b/test/capture-stdout-stderr.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+"use strict";
+
+const supportsColor = require("supports-color");
+
+function stderrColor(str) {
+    if (supportsColor.stderr && !process.env.TEST_LOG_DISABLE_COLOR) {
+        return `\u001b[33m${str}\u001b[0m`;
+    } else {
+        return str;
+    }
+}
+
+function chunkToString(chunk) {
+    if (typeof chunk === 'string') {
+        return chunk;
+    }
+    return chunk.toString('utf8');
+}
+
+const _global = global;
+if (!_global['capture-stdout-stderr']) {
+    _global['capture-stdout-stderr'] = {
+        stdout: process.stdout.write,
+        stderr: process.stderr.write,
+    };
+}
+
+const lines = [];
+
+function overwrite(std) {
+    process[std].write = (chunk) => {
+        const str = chunkToString(chunk);
+        lines.push({
+            [std]: str
+        });
+        if (this.print) {
+            _global['capture-stdout-stderr'][std].call(process[std], std === "stderr" ? stderrColor(str) : str );
+        }
+        return true;
+    };
+}
+
+module.exports = {
+    print: false,
+
+    start() {
+        lines.length = 0;
+        overwrite.call(this, "stdout");
+        overwrite.call(this, "stderr");
+    },
+
+    stop() {
+        process.stdout.write = _global['capture-stdout-stderr'].stdout;
+        process.stderr.write = _global['capture-stdout-stderr'].stderr;
+    },
+
+    get output() {
+        return {
+            get stdout() {
+                return lines.map((l) => l.stdout || "").join("");
+            },
+            get stderr() {
+                return lines.map((l) => l.stderr || "").join("");
+            },
+            get any() {
+                return lines.map((l) => l.stdout || l.stderr).join("");
+            }
+        };
+    },
+
+    replay() {
+        for (const line of lines) {
+            if (line.stdout) {
+                process.stdout.write(line.stdout);
+            } else if (line.stderr) {
+                process.stderr.write(stderrColor(line.stderr));
+            }
+        }
+    }
+};

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -49,7 +49,7 @@ describe("cli e2e", function() {
     it("help", async function() {
         await sizewatcher(["-h"]);
 
-        assert(this.stderr.output.includes("Usage: sizewatcher [<options>] [<before> [<after>]]"));
+        assert(this.output.stderr.includes("Usage: sizewatcher [<options>] [<before> [<after>]]"));
 
         assert.strictEqual(lastExitCode, 1);
     });
@@ -60,7 +60,7 @@ describe("cli e2e", function() {
         await sizewatcher();
 
         assert.strictEqual(lastExitCode, 1);
-        assert(this.stderr.output.includes("Error: Not inside a git checkout"));
+        assert(this.output.stderr.includes("Error: Not inside a git checkout"));
     });
 
     it("local branch", async function() {
@@ -74,7 +74,8 @@ describe("cli e2e", function() {
         await sizewatcher();
 
         assert.strictEqual(lastExitCode, undefined);
-        assert(this.stdout.output.includes("'main' => 'new'"));
-        assert(this.stdout.output.includes("+ ✅  git: -0.0%"));
+        assert(this.output.stdout.includes("'main' => 'new'"));
+        assert(this.output.stdout.includes("+ ✅  git: -0.0%"));
     });
+
 });


### PR DESCRIPTION
Replace [stdout-stderr](https://www.npmjs.com/package/stdout-stderr) with own solution [capture-stdout-stderr.js](https://github.com/adobe/sizewatcher/blob/332188bc856c9aa91266f693e524d29ed7a3ba8a/test/capture-stdout-stderr.js) that

- keeps order between stdout and stderr on `replay()`
- prints stderr in color
- allows matching against stdout AND stderr using `output.any`