### PR TITLE
CI: setting permissions for GITHUB_TOKEN to write-all

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,7 +11,8 @@ jobs:
 
     runs-on: ubuntu-latest
     
-    # permissions: write-all
+    permissions:
+      pull-requests: write
 
     strategy:
       matrix:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,6 +10,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    
+    permissions: write-all
 
     strategy:
       matrix:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,7 +11,7 @@ jobs:
 
     runs-on: ubuntu-latest
     
-    permissions: write-all
+    # permissions: write-all
 
     strategy:
       matrix:


### PR DESCRIPTION
Trying to fix build issues in recent PRs, such as #84.

These are failing because the GITHUB_TOKEN passed in by github actions automatically by default do not have the permission to write/update comments on the PR **if they are coming from dependabot**.

Documentation links:
* https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
* https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
* https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository