### PR TITLE
chore: update simple-git to 3.22 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "js-yaml": "4.1.0",
         "pretty-bytes": "5.3.0",
         "require-dir": "1.2.0",
-        "simple-git": "3.16.0",
+        "simple-git": "3.22.0",
         "tmp": "0.2.1",
         "xbytes": "1.6.2"
       },
@@ -4167,9 +4167,10 @@
       "dev": true
     },
     "node_modules/simple-git": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.16.0.tgz",
-      "integrity": "sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.22.0.tgz",
+      "integrity": "sha512-6JujwSs0ac82jkGjMHiCnTifvf1crOiY/+tfs/Pqih6iow7VrpNKRRNdWm6RtaXpvvv/JGNYhlUtLhGFqHF+Yw==",
+      "license": "MIT",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
@@ -8059,9 +8060,9 @@
       "dev": true
     },
     "simple-git": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.16.0.tgz",
-      "integrity": "sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.22.0.tgz",
+      "integrity": "sha512-6JujwSs0ac82jkGjMHiCnTifvf1crOiY/+tfs/Pqih6iow7VrpNKRRNdWm6RtaXpvvv/JGNYhlUtLhGFqHF+Yw==",
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "js-yaml": "4.1.0",
     "pretty-bytes": "5.3.0",
     "require-dir": "1.2.0",
-    "simple-git": "3.16.0",
+    "simple-git": "3.22.0",
     "tmp": "0.2.1",
     "xbytes": "1.6.2"
   }

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
     ],
     "timezone": "America/Los_Angeles",
     "branchPrefix": "renovate-",
+    "ignoreDeps": ["simple-git"],
     "packageRules": [
       {
         "groupName": "minor and patch version changes",


### PR DESCRIPTION
simple-git `3.22` is the latest version that works with node 12 and prevent updates from renovate.

see e.g. https://github.com/serverless/serverless/issues/12418

triggered by https://github.com/adobe/sizewatcher/actions/runs/14140368425/job/39620636615?pr=102
