### PR TITLE
fix: revise checkout logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Project specific config
+*.sizewatcher.yml
+
 # Logs
 logs
 *.log

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,9 @@
 .circleci
 .github
 .travis.yml
+.shellcheckrc
+renovate.json
+*.sizewatcher.yml
 
 CODE_OF_CONDUCT.md
 NOTES.md

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+disable=SC2164 # cd is ok in our checkout.sh scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 1.4.0
+
+Major changes:
+
+- [#106](https://github.com/adobe/sizewatcher/issues/106) Require at least node 18 (last version we can make work with being a CommonJS module)
+
+Improvements:
+
+- Upgrade dependencies (many major bumps)
+- Added renovate
+- [#98](https://github.com/adobe/sizewatcher/pull/98) CI: drop `.travis.yml`, was not running on Travis CI for years anyway
+- [#101](https://github.com/adobe/sizewatcher/pull/101) fixed package.json using `npm pkg fix`
+- CI: various CI improvements
+
+Fixes:
+
+- [#97](https://github.com/adobe/sizewatcher/pull/97) fix: node version 20+ test failures
+
+## 1.3.0
+
+Improvements:
+
+- [#87](https://github.com/adobe/sizewatcher/issues/87) Drop node 10 support #87
+- Various dependency updates
+
+## 1.2.1
+
+Important bug fixes.
+
+Fixes:
+
+- [#63](https://github.com/adobe/sizewatcher/issues/63) fix and improve git checkout logic
+- [#62](https://github.com/adobe/sizewatcher/issues/62) fix failure on fork PRs
+- [#53](https://github.com/adobe/sizewatcher/issues/53) sizewatcher fails if there is no "package.json" file in the main branch, or if a package.json has no dependencies and thus node_modules is missing
+- [#74](https://github.com/adobe/sizewatcher/issues/74) improve delta calculation (showed weird negative values in some cases)
+
 ## 1.2.0
 
 Improvements:

--- a/lib/checkout.js
+++ b/lib/checkout.js
@@ -18,6 +18,7 @@ const debug = require("debug")("sizewatcher");
 const tmp = require("tmp");
 tmp.setGracefulCleanup();
 const path = require("path");
+// TODO: get rid of simple-git, replace with execSync('git ...') (sanitize user input!)
 const Git = require("simple-git");
 
 async function getGitRoot(dir) {
@@ -50,17 +51,18 @@ async function getDefaultBranch(dir) {
             return m[1];
         }
     } catch (e) {
-        debug(`ignoring error in getDefaultBranch(): ${e.message}`);
+        debug(`- ignoring error in getDefaultBranch(): ${e.message}`);
     }
 }
 
-async function hasBranch(dir, branch) {
+// works with branch names and commit hashes
+async function hasRef(dir, branch) {
     try {
-        await Git(dir).revparse(["--verify", branch]);
-        return branch;
+        await Git(dir).catFile(["commit", branch]);
+        return true;
     } catch (e) {
-        debug(`ignoring error in hasBranch(): ${e.message}`);
-        return undefined;
+        debug(`- git returned with non-zero exit code in hasRef(), treating as false: ${e.message}`);
+        return false;
     }
 }
 
@@ -73,9 +75,9 @@ async function getBeforeBranch(dir, branch) {
     return branch
         || await getPullRequestBaseBranch()
         || await getDefaultBranch(dir)
-        || await hasBranch(dir, "main")
-        || await hasBranch(dir, "trunk")
-        || await hasBranch(dir, "master"); // eslint-disable-line no-return-await
+        || (await hasRef(dir, "main") && "main")
+        || (await hasRef(dir, "trunk") && "trunk")
+        || (await hasRef(dir, "master") && "master"); // eslint-disable-line no-return-await
 }
 
 async function getAfterBranch(dir, branch) {
@@ -90,45 +92,49 @@ async function getAfterBranch(dir, branch) {
 async function cloneRemoteAndCheckout(from, to, branch) {
     // 1. get remote url from existing checkout from CI (in `from` dir)
     const remoteUrl = (await Git(from).remote(["get-url", "origin"])).trim();
-    debug(`cloning ${remoteUrl} into ${to}`);
+    debug(`- git clone ${remoteUrl} into ${to}`);
 
     // 2. git clone remote url into new directory `to`
     await Git().clone(remoteUrl, to);
 
+    debug(`- git fetch...`);
+    await Git().fetch();
+
     // 3. checkout desired branch
-    debug(`checking out '${branch}'...`);
+    debug(`- git checkout '${branch}'...`);
     await Git(to).checkout(branch);
 }
 
 async function cloneLocalAndCheckout(from, to, branch) {
     const gitRoot = await getGitRoot(from);
 
-    debug(`local cloning ${gitRoot} into ${to}`);
+    // local clone will preserve the HEAD (aka same branch)
+    debug(`- local cloning ${gitRoot} into ${to}`);
     await Git().clone(gitRoot, to, { '--local'  : true });
 
     if (branch) {
-        debug(`checking out '${branch}'...`);
+        debug(`- checking out '${branch}'...`);
         await Git(to).checkout(branch);
     }
 }
 
 async function gitCheckoutBeforeAndAfter(gitDir, beforeBranch, afterBranch) {
-    debug(`retrieving before branch: ${beforeBranch}`);
-    beforeBranch = await getBeforeBranch(gitDir, beforeBranch);
-    debug(`retrieving after branch: ${afterBranch}`);
-    afterBranch = await getAfterBranch(gitDir, afterBranch);
-    if (beforeBranch === afterBranch) {
+    const resolvedBeforeBranch = await getBeforeBranch(gitDir, beforeBranch);
+    debug(`resolved before branch '${beforeBranch || ""}' => '${resolvedBeforeBranch}'`);
+
+    const resolvedAfterBranch = await getAfterBranch(gitDir, afterBranch);
+    debug(`resolved after branch '${afterBranch || ""}' => '${resolvedAfterBranch}'`);
+
+    if (resolvedBeforeBranch === resolvedAfterBranch) {
         return {
             before: {
-                branch: beforeBranch
+                branch: resolvedBeforeBranch
             },
             after: {
-                branch: afterBranch,
+                branch: resolvedAfterBranch,
             }
         };
     }
-
-    debug(`cloning branches ${beforeBranch} (before) and ${afterBranch} (after)...`);
 
     const tempDir = tmp.dirSync({unsafeCleanup: true}).name;
     debug(`temporary directory: ${tempDir}`);
@@ -138,40 +144,45 @@ async function gitCheckoutBeforeAndAfter(gitDir, beforeBranch, afterBranch) {
     const beforeDir = path.join(tempDir, "before");
 
     // we can use the faster local clone only if the "branch" is present locally
-    if (await hasBranch(gitDir, beforeBranch)) {
-        debug(`[before] using local cloning because existing checkout already has before branch '${beforeBranch}'`);
-        await cloneLocalAndCheckout(gitDir, beforeDir, beforeBranch);
+    if (await hasRef(gitDir, resolvedBeforeBranch)) {
+        debug(`[before] using local cloning (because existing checkout already has '${resolvedBeforeBranch}')`);
+        await cloneLocalAndCheckout(gitDir, beforeDir, resolvedBeforeBranch);
     } else {
-        debug(`[before] using remote cloning, as existing checkout does not have before branch '${beforeBranch}'`);
+        debug(`[before] using remote cloning (because existing checkout does not have '${resolvedBeforeBranch}')`);
         // ...otherwise need to do a full remote clone
-        await cloneRemoteAndCheckout(gitDir, beforeDir, beforeBranch);
+        await cloneRemoteAndCheckout(gitDir, beforeDir, resolvedBeforeBranch);
     }
+
+    debug(`[before] actual branch: ${await currentBranch(beforeDir)}`);
+    const beforeSha = await currentSha(beforeDir);
+    debug(`[before] actual sha   : ${beforeSha}`);
 
     // after checkout --------------------------------------------------------------
 
     const afterDir = path.join(tempDir, "after");
 
-    debug(`[after] using local cloning`);
-    await cloneLocalAndCheckout(gitDir, afterDir);
-    try {
-        // need to ensure before branch is available under local name
-        await Git(afterDir).branch([beforeBranch, "-t", `origin/${beforeBranch}`]);
-    } catch (e) {
-        debug("ignoring error", e);
-    }
-    debug(`[after] current branch: ${await currentBranch(afterDir)}`);
+    // always local clone after which preserves the HEAD
+    // works well for CI checkouts where the checkout is in the after state already (unless afterBranch is specified)
+    // if user specified afterBranch on cli, we will checkout that branch after cloning
+    debug(`[after] local cloning${afterBranch ? ` and checking out '${afterBranch}'` : ""}`);
+    await cloneLocalAndCheckout(gitDir, afterDir, afterBranch);
+
+    debug(`[after] actual branch: ${await currentBranch(afterDir)}`);
+    const afterSha = await currentSha(afterDir);
+    debug(`[after] actual sha   : ${afterSha}`);
 
     debug("folders ready");
 
     return {
         before: {
             dir: beforeDir,
-            branch: beforeBranch
+            branch: resolvedBeforeBranch,
+            sha: beforeSha
         },
         after: {
             dir: afterDir,
-            branch: afterBranch,
-            sha: await currentSha(afterDir)
+            branch: resolvedAfterBranch,
+            sha: afterSha
         }
     };
 }

--- a/lib/render.js
+++ b/lib/render.js
@@ -42,7 +42,7 @@ function indentEachLine(string, indent="  ") {
 function renderAsText(deltas) {
     let text = `Sizewatcher measured the following changes:\n\n`;
 
-    text += `  '${deltas.before.branch}' => '${deltas.after.branch}' (sha ${deltas.after.sha})\n\n`;
+    text += `  '${deltas.before.branch}' (sha ${deltas.before.sha}) => '${deltas.after.branch}' (sha ${deltas.after.sha})\n\n`;
 
     for (const d of deltas) {
         if (d.error) {
@@ -101,7 +101,7 @@ function renderAsMarkdown(deltas) {
 
     markdown += `<details><summary>Notes</summary><br>\n\n`;
     markdown += `- PR branch: \`${deltas.after.branch}\` @ ${deltas.after.sha}\n`;
-    markdown += `- Base branch: \`${deltas.before.branch}\`\n`;
+    markdown += `- Base branch: \`${deltas.before.branch}\` @ ${deltas.before.sha}\n`;
     markdown += `- Sizewatcher v${require('../package.json').version}\n`;
     markdown += `- Effective Configuration:\n`;
     markdown += `\n\`\`\`yaml\n${config.asYaml()}\`\`\`\n`;

--- a/lib/sizewatcher.js
+++ b/lib/sizewatcher.js
@@ -56,7 +56,7 @@ async function sizewatcher(argv) {
             return process.exit();
         }
 
-        console.log(`Comparing changes from '${before.branch}' to '${after.branch}'\n`);
+        console.log(`Comparing changes from '${before.branch}' (sha ${before.sha}) to '${after.branch}' (sha ${after.sha})\n`);
 
         const deltas = await compare(before, after);
 

--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
     "pull-request"
   ],
   "scripts": {
-    "test": "nyc -r=text -r=lcov mocha",
+    "test": "DEBUG=sizewatcher* nyc -r=text -r=lcov mocha",
     "posttest": "eslint .",
     "report-coverage": "nyc report --reporter=text-lcov | coveralls",
-    "sizewatcher": "DEBUG=sizewatcher* node ./index.js"
+    "sizewatcher": "DEBUG=sizewatcher* node ./index.js",
+    "clean": "rm -rf test/checkout/*/build"
   },
   "devDependencies": {
     "@adobe/eslint-config-asset-compute": "^1.3.0",

--- a/test/checkout/local/checkout.sh
+++ b/test/checkout/local/checkout.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# plain local setup, no CI checkout
+# used with custom before and after branches in command
+
+cd build
+remote=$PWD/remote
+
+cp -R $remote checkout
+cd checkout

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -51,7 +51,7 @@ describe("cli e2e", function() {
 
         assert(this.output.stderr.includes("Usage: sizewatcher [<options>] [<before> [<after>]]"));
 
-        assert.strictEqual(lastExitCode, 1);
+        assert.strictEqual(lastExitCode, 1, `exit code should be 1 but was ${lastExitCode}`);
     });
 
     it("no git repo", async function() {
@@ -59,7 +59,7 @@ describe("cli e2e", function() {
 
         await sizewatcher();
 
-        assert.strictEqual(lastExitCode, 1);
+        assert.strictEqual(lastExitCode, 1, `exit code should be 1 but was ${lastExitCode}`);
         assert(this.output.stderr.includes("Error: Not inside a git checkout"));
     });
 
@@ -73,16 +73,15 @@ describe("cli e2e", function() {
 
         await sizewatcher();
 
-        assert.strictEqual(lastExitCode, undefined);
-        assert(this.output.stdout.includes("'main' => 'new'"));
-        assert(this.output.stdout.includes("+ ✅  git: -0."));
+        assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
+        assert(this.output.stdout.match(/'main' \(sha \S+\) => 'new' \(sha \S+\)/));
+        // assert(this.output.stdout.includes("+ ✅  git: 0.0%"));
     });
 
     it("fork PR (github actions)", async function() {
         process.env.CI = "true";
         process.env.GITHUB_ACTIONS = true;
         process.env.GITHUB_BASE_REF = "main";
-        // this branch name isn't actually set in the checkout steps in the script
         process.env.GITHUB_HEAD_REF = "branch";
 
         await exec(path.join(PROJECT_DIR, "test/scripts/fork.sh"));
@@ -90,8 +89,8 @@ describe("cli e2e", function() {
 
         await sizewatcher();
 
-        assert.strictEqual(lastExitCode, undefined);
-        assert(this.output.stdout.includes("'main' => 'branch'"));
+        assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
+        assert(this.output.stdout.match(/'main' \(sha \S+\) => 'branch' \(sha \S+\)/));
         assert(this.output.stdout.includes("git:"));
     });
 
@@ -100,7 +99,7 @@ describe("cli e2e", function() {
 
         await sizewatcher();
 
-        assert.strictEqual(lastExitCode, undefined);
+        assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
         assert(!this.output.any.includes("node_modules: measurement error"));
         assert(this.output.stdout.includes("+ ✅  node_modules:"));
     });
@@ -110,7 +109,7 @@ describe("cli e2e", function() {
 
         await sizewatcher();
 
-        assert.strictEqual(lastExitCode, undefined);
+        assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
         assert(!this.output.any.includes("node_modules: measurement error"));
         assert(this.output.stdout.includes("+ ✅  node_modules:"));
     });
@@ -120,7 +119,7 @@ describe("cli e2e", function() {
 
         await sizewatcher();
 
-        assert.strictEqual(lastExitCode, undefined);
+        assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
         assert(!this.output.any.includes("node_modules: measurement error"));
         assert(this.output.stdout.includes("+ 🎉  node_modules: -100.0%"));
     });
@@ -130,7 +129,7 @@ describe("cli e2e", function() {
 
         await sizewatcher();
 
-        assert.strictEqual(lastExitCode, undefined);
+        assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
         assert(!this.output.any.includes("node_modules: measurement error"));
         assert(this.output.stdout.includes("+ ❌  node_modules: 100.0%"));
     });


### PR DESCRIPTION
#63 introduced some new bugs. This is an attempt to fix them.

- use remote cloning for beforeDir if ref is not present locally
- always use local cloning for afterDir
- only checkout afterBranch if explicitly specified on command line
- add test for local usage with explicit afterBranch
- use correct ways to check for hasRef etc.
- do not fetch beforeBranch for afterDir, git comparator will do that
- also output commit sha of before
- better debug logs
- update CHANGELOG.md