### PR TITLE
Fix broken tests on latest Node 26.8

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,6 +15,7 @@ jobs:
       pull-requests: write
 
     strategy:
+      fail-fast: false
       matrix:
         node-version: [18, "lts/*", "latest"]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "coveralls": "^3.1.0",
         "eslint": "^8.0.0",
         "mocha": "^11.0.0",
-        "mock-fs": "^5.5.0",
         "nyc": "^17.0.0",
         "supports-color": "^8.1.1"
       }
@@ -3689,16 +3688,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mock-fs": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.5.0.tgz",
-      "integrity": "sha512-d/P1M/RacgM3dB0sJ8rjeRNXxtapkPCUnMGmIN0ixJ16F/E4GUZCvWcSGfWGz8eaXYvn1s9baUwNjI4LOPEjiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/ms": {
@@ -8088,12 +8077,6 @@
           "dev": true
         }
       }
-    },
-    "mock-fs": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.5.0.tgz",
-      "integrity": "sha512-d/P1M/RacgM3dB0sJ8rjeRNXxtapkPCUnMGmIN0ixJ16F/E4GUZCvWcSGfWGz8eaXYvn1s9baUwNjI4LOPEjiA==",
-      "dev": true
     },
     "ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "coveralls": "^3.1.0",
     "eslint": "^8.0.0",
     "mocha": "^11.0.0",
-    "mock-fs": "^5.5.0",
     "nyc": "^17.0.0",
     "supports-color": "^8.1.1"
   },

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -13,17 +13,38 @@
 'use strict';
 
 const assert = require("assert");
-const mockFs = require("mock-fs");
+const fs = require("fs");
+const path = require("path");
+const tmp = require("tmp");
+tmp.setGracefulCleanup();
+
 const config = require("../lib/config");
+
+const CONFIG_FILE = ".sizewatcher.yml";
+
+// switch into a clean new temporary directory, optionally with a config file
+function mockConfig(content) {
+    const tmpDir = tmp.dirSync({unsafeCleanup: true}).name;
+    process.chdir(tmpDir);
+    if (content !== undefined) {
+        fs.writeFileSync(path.join(tmpDir, CONFIG_FILE), content);
+    }
+}
 
 describe("config", function() {
 
+    let originalCwd;
+
+    beforeEach(function() {
+        originalCwd = process.cwd();
+    });
+
     afterEach(function() {
-        mockFs.restore();
+        process.chdir(originalCwd);
     });
 
     it("loads default config if no config file exists", function() {
-        mockFs();
+        mockConfig();
         const cfg = config.reload();
         assert.strictEqual(typeof cfg, "object");
         assert.deepStrictEqual(cfg.limits, {
@@ -37,9 +58,7 @@ describe("config", function() {
     });
 
     it("loads config file that is empty", function() {
-        mockFs({
-            ".sizewatcher.yml": ""
-        });
+        mockConfig("");
         const cfg = config.reload();
         assert.strictEqual(typeof cfg, "object");
         assert.deepStrictEqual(cfg.limits, {
@@ -53,13 +72,10 @@ describe("config", function() {
     });
 
     it("loads config file with percentage limits", function() {
-        mockFs({
-            ".sizewatcher.yml":
-`
+        mockConfig(`
 limits:
     fail: 42%
-`
-        });
+`);
         const cfg = config.reload();
         assert.strictEqual(typeof cfg, "object");
         assert.deepStrictEqual(cfg.limits, {
@@ -70,15 +86,12 @@ limits:
     });
 
     it("loads config file with integer limits", function() {
-        mockFs({
-            ".sizewatcher.yml":
-`
+        mockConfig(`
 limits:
     fail: 1000
     warn: 100
     ok: 50
-`
-        });
+`);
         const cfg = config.reload();
         assert.strictEqual(typeof cfg, "object");
         assert.deepStrictEqual(cfg.limits, {
@@ -89,14 +102,11 @@ limits:
     });
 
     it("loads config file with reportStatus", function() {
-        mockFs({
-            ".sizewatcher.yml":
-`
+        mockConfig(`
 report:
     githubComment: false
     githubStatus: true
-`
-        });
+`);
         const cfg = config.reload();
         assert.strictEqual(typeof cfg, "object");
         assert.strictEqual(cfg.report.githubComment, false);
@@ -104,7 +114,7 @@ report:
     });
 
     it("returns default config in asYaml() if no config file exists", function() {
-        mockFs();
+        mockConfig();
         config.reload();
         const yaml = config.asYaml();
         assert.strictEqual(yaml, `limits:
@@ -119,15 +129,12 @@ comparators: {}
     });
 
     it("handles a single custom comparators", function() {
-        mockFs({
-            ".sizewatcher.yml":
-`
+        mockConfig(`
 comparators:
   custom:
     name: mine
     path: build/file
-`
-        });
+`);
         const cfg = config.reload();
         assert.strictEqual(typeof cfg, "object");
         assert.strictEqual(typeof cfg.comparators.custom, "object");
@@ -136,16 +143,13 @@ comparators:
     });
 
     it("handles a multiple custom comparators", function() {
-        mockFs({
-            ".sizewatcher.yml":
-`
+        mockConfig(`
 comparators:
   custom:
     - name: mine
       path: build/file
     - path: build/file2
-`
-        });
+`);
         const cfg = config.reload();
         assert.strictEqual(typeof cfg, "object");
         assert.ok(Array.isArray(cfg.comparators.custom));


### PR DESCRIPTION
Tests are broken against latest node versions.

## Root cause

Node 26.8.0 rewrote fs.readFile (nodejs/node#65327) so it no longer calls the internal open binding from JavaScript. mock-fs 5.5.0 relies on intercepting that call at require time to find the ReadFileContext prototype. It now gets undefined and throws before any test runs. This is tracked upstream as tschaub/mock-fs#447, opened August 27, still open with no fix. I reproduced the failure locally on Node 26.8.2 with the unmodified test.

## Fix

Dropped mock-fs entirely rather than pin Node or wait for upstream. The config tests now create a fresh temp directory, write .sizewatcher.yml into it when needed, and chdir into it. This mirrors the pattern already used in cli.test.js, and the tmp package is already a runtime dependency. Working directory is restored after each test.

## Changes

- removed mock-fs and using a real /tmp directory in tests
- CI: disable fail-fast on node version matrix, so we alway see all version test results
