### PR TITLE
update CircleCI config to version 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@
 # OF ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-version: 2
+version: 2.1
 
 jobs:
   build:
@@ -29,3 +29,8 @@ jobs:
 
       - run: npm run sizewatcher
       - run: npm test
+
+workflows:
+  build-and-test:
+    jobs:
+      - build

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ For [CircleCI](https://circleci.com) you need to
 Example `.circleci/config.yml`:
 
 ```yaml
-version: 2
+version: 2.1
 
 jobs:
   build:
@@ -330,6 +330,11 @@ jobs:
 
       # ---------- this runs sizewatcher ------------
       - run: npx @adobe/sizewatcher
+
+workflows:
+  build-and-test:
+    jobs:
+      - build
 ```
 
 ### Other CIs

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:lts
     steps:
       - checkout
 


### PR DESCRIPTION
## Summary

- Bump `.circleci/config.yml` from `version: 2` to `version: 2.1`. CircleCI stops compiling 2.0 configs on September 21, 2026 ([announcement](https://discuss.circleci.com/t/breaking-changes-config-compilation-updates-september-21-2026/54719)).
- Add an explicit `workflows` block running the existing `build` job instead of relying on the implicit default.
- Apply the same two changes to the example CircleCI config in the README so users copying it are not affected either, and switch its image from the deprecated `circleci/node:14` to `cimg/node:lts`.

The other two breaking changes in the announcement (undeclared parameters, regex engine) do not apply: this config has no parameters, regex filters, heredocs, or job-level branch filters.

## Test plan

- `circleci config validate .circleci/config.yml` passes
- `circleci config validate .circleci/config.yml --next` passes against the new compiler
- `npm test` passes (22 tests)
- `eslint .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
