### PR TITLE
set root: true in ESLint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@
 'use strict';
 
 module.exports = {
+    "root": true,
     "extends": "@adobe/eslint-config-asset-compute",
     "parserOptions": {
         "ecmaVersion": 2020


### PR DESCRIPTION
## Summary

- Add `root: true` to `.eslintrc.js` so ESLint stops config resolution at the project root instead of cascading into parent directories.
- Without it, running `eslint .` (and therefore the `posttest` hook) from a git worktree nested under the main checkout fails: ESLint merges the parent checkout's config, finds a second copy of the mocha plugin from a different `node_modules`, and refuses to load it.
- `root: true` is also the correct setting for a standalone package. CI on GitHub was never affected since it only has a single checkout.

## Test plan

- `npx eslint .` passes in a nested worktree (failed before this change)
- `npm test`: 22 passing, `posttest` lint hook exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)