### PR TITLE
Raise test coverage from 73% to over 99%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,13 @@ Improvements:
 - ESLint 10 with flat config (`eslint.config.mjs`) and `eslint-config-problems` instead of the unmaintained `@adobe/eslint-config-asset-compute`
 - Renovate: package rules with version ceilings instead of `ignoreDeps`, weekly lockfile maintenance and vulnerability alert PRs
 - `package.json` declares `engines` (runtime) and `devEngines` (development)
+- Test coverage raised from 73% to over 99%: unit tests for `render`, `compare`, `size`, `github` (against a local fake GitHub API server) and `report`, plus new end-to-end cases for the checkout logic (identical branches, `master`/`trunk` default branches, before commit sha, unknown branch, Travis PR and branch builds), custom comparators, `npm_package` incl. the `dir` option, `package-lock.json` and configured limits. The e2e tests clear all CI github env vars so they can never talk to the real GitHub API
 
 Fixes:
 
 - Error message of a failing `npx howfat` run included stdout twice instead of stderr
+- A measurement error (`summary: error`) set a green `success` commit status without description; it now sets an `error` status with a description
+- Fractional percentage limits such as `0.5%` were truncated to integers
 
 ## 1.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Fixes:
 - Error message of a failing `npx howfat` run included stdout twice instead of stderr
 - A measurement error (`summary: error`) set a green `success` commit status without description; it now sets an `error` status with a description
 - Fractional percentage limits such as `0.5%` were truncated to integers
+- A `GITHUB_API_URL` with a trailing slash (as previously shown in the README) resulted in invalid `//repos/...` API urls
 
 ## 1.4.2
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ This token should be a service/bot user that has read/pull permission on the rep
 If you use Github Enterprise, set the custom [Github API URL](https://docs.github.com/en/enterprise-server@2.21/rest/reference/enterprise-admin) in the `GITHUB_API_URL` environment variable:
 
 ```
-GITHUB_API_URL=https://mygithub.company.com/api/v3/
+GITHUB_API_URL=https://mygithub.company.com/api/v3
 ```
 
 This is not required for public github.com.

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -15,7 +15,7 @@
 // compare.js - runs the comparators on the before/after checkouts
 
 const debug = require("debug")("sizewatcher");
-const config = require("./config").get();
+const config = require("./config");
 const COMPARATORS = require('require-dir')("./comparators");
 const xbytes = require('xbytes');
 const path = require("path");
@@ -45,6 +45,7 @@ async function runComparator(comparator, before, after, deltas) {
 
 async function compare(before, after) {
     const deltas = [];
+    const { comparators: comparatorConfigs } = config.get();
 
     console.log("Calculating size changes for");
 
@@ -68,7 +69,7 @@ async function compare(before, after) {
 
         if (type === "custom") {
             // custom comparator, multiple could be configured
-            let customConfigs = config.comparators.custom;
+            let customConfigs = comparatorConfigs.custom;
             if (!customConfigs) {
                 continue;
             }
@@ -83,7 +84,7 @@ async function compare(before, after) {
 
         } else {
             // fixed comparators
-            const comparatorConfig = config.comparators[type];
+            const comparatorConfig = comparatorConfigs[type];
             if (comparatorConfig === false) {
                 debug(`skipping '${type}' because disabled in config`);
                 continue;
@@ -126,8 +127,8 @@ function exceeds(value, increasePct, limit) {
     if (typeof limit === "string") {
         limit = limit.trim();
         if (limit.endsWith("%")) {
-            // "50%" parses as 50
-            return increasePct >= Number.parseInt(limit);
+            // "50%" parses as 50, "0.5%" as 0.5
+            return increasePct >= Number.parseFloat(limit);
         } else {
             const bytes = xbytes.parseSize(limit);
             if (bytes === undefined) {
@@ -149,6 +150,7 @@ function processDeltas(deltas) {
         fail: 0,
         error: 0
     };
+    const globalLimits = config.get().limits;
 
     for (const d of deltas) {
         debug("processing delta:", d);
@@ -158,8 +160,8 @@ function processDeltas(deltas) {
         }
         // merge limit config, comparator-specific one wins over global
         const limits = {
-            ...config.limits,
-            ...d.config.limits
+            ...globalLimits,
+            ...(d.config && d.config.limits)
         };
 
         let increase;
@@ -208,3 +210,6 @@ function processDeltas(deltas) {
 }
 
 module.exports = compare;
+// exposed for unit tests
+compare.exceeds = exceeds;
+compare.processDeltas = processDeltas;

--- a/lib/github.js
+++ b/lib/github.js
@@ -15,9 +15,16 @@
 // github.js - github client to report PR comments etc.
 
 const { Octokit } = require("@octokit/rest");
+
+function getBaseUrl() {
+    const url = process.env.GITHUB_API_URL;
+    // octokit appends paths starting with "/", a trailing slash would result in "//repos/..." urls
+    return url ? url.replace(/\/+$/, "") : undefined;
+}
+
 const github = new Octokit({
     auth: process.env.GITHUB_TOKEN,
-    baseUrl: process.env.GITHUB_API_URL
+    baseUrl: getBaseUrl()
 });
 
 async function getPullRequestForBranch(owner, repo, branch) {

--- a/lib/report.js
+++ b/lib/report.js
@@ -17,13 +17,20 @@
 const debug = require("debug")("sizewatcher");
 const render = require("./render");
 const github = require("./github");
-const config = require("./config").get();
+const config = require("./config");
 
 const STATUS_TEXTS = {
     cheers: "Size is decreasing, perfect!",
     ok: "Size changes are ok.",
     warn: "Size is increasing, but still ok.",
-    fail: "Size increase is too high!"
+    fail: "Size increase is too high!",
+    error: "Measurement error, see PR comment."
+};
+
+// github commit status states: error, failure, pending, success
+const STATUS_STATES = {
+    fail: "failure",
+    error: "error"
 };
 
 function parseRepoSlug(slug) {
@@ -101,7 +108,7 @@ async function reportAsGithubComment(repo, deltas) {
 }
 
 async function reportAsGithubStatus(repo, deltas, commentUrl) {
-    const status = deltas.summary === "fail" ? "failure" : "success";
+    const status = STATUS_STATES[deltas.summary] || "success";
     debug("setting commit status in github:", status, "url:", commentUrl);
 
     await github.setCommitStatus(
@@ -119,7 +126,9 @@ async function report(deltas) {
     console.log();
     console.log(render.asText(deltas));
 
-    if (!config.report.githubComment && !config.report.githubStatus) {
+    const { report: reportConfig } = config.get();
+
+    if (!reportConfig.githubComment && !reportConfig.githubStatus) {
         return;
     }
 
@@ -138,11 +147,11 @@ async function report(deltas) {
     }
 
     let commentUrl;
-    if (config.report.githubComment) {
+    if (reportConfig.githubComment) {
         commentUrl = await reportAsGithubComment(repo, deltas);
     }
 
-    if (config.report.githubStatus) {
+    if (reportConfig.githubStatus) {
         await reportAsGithubStatus(repo, deltas, commentUrl);
     }
 }

--- a/lib/size.js
+++ b/lib/size.js
@@ -56,18 +56,7 @@ function getFolderRegex(dir) {
     return new RegExp(`^${escapeRegex(dir)}(\\/.*)?$`);
 }
 
-/**
- * Get a regex pattern that matches a file exactly.
- *
- * @param {String} file Path to the file
- * @returns {RegExp} The regex pattern
- */
-function getFileRegex(file) {
-    return new RegExp(`^${escapeRegex(file)}$`);
-}
-
 module.exports = {
     getFileSize,
-    getFolderRegex,
-    getFileRegex
+    getFolderRegex
 };

--- a/test/checkout.test.js
+++ b/test/checkout.test.js
@@ -53,10 +53,12 @@ function cleanEnvVars() {
     delete process.env.GITHUB_BASE_REF;
     delete process.env.GITHUB_HEAD_REF;
     delete process.env.TRAVIS;
+    delete process.env.TRAVIS_PULL_REQUEST;
     delete process.env.TRAVIS_PULL_REQUEST_BRANCH;
     delete process.env.TRAVIS_BRANCH;
     delete process.env.CIRCLECI;
     delete process.env.CIRCLE_BRANCH;
+    delete process.env.CIRCLE_PULL_REQUEST;
 }
 
 // clones are local and fast, but node:test has no default timeout
@@ -85,6 +87,23 @@ describe("checkout", function() {
         process.env.CI = "true";
         process.env.TRAVIS = true;
         await run("test/checkout/travis");
+    }));
+
+    it("handles travis pull request builds", TIMEOUT, captured(async () => {
+        process.env.CI = "true";
+        process.env.TRAVIS = true;
+        process.env.TRAVIS_PULL_REQUEST = "1";
+        process.env.TRAVIS_BRANCH = "main";
+        process.env.TRAVIS_PULL_REQUEST_BRANCH = "branch";
+        await run("test/checkout/normal");
+    }));
+
+    it("handles travis branch builds", TIMEOUT, captured(async () => {
+        process.env.CI = "true";
+        process.env.TRAVIS = true;
+        process.env.TRAVIS_PULL_REQUEST = "false";
+        process.env.TRAVIS_BRANCH = "branch";
+        await run("test/checkout/normal");
     }));
 
     it("handles circleci checkouts", TIMEOUT, captured(async () => {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -18,6 +18,7 @@ const path = require("path");
 const tmp = require("tmp");
 tmp.setGracefulCleanup();
 const sizewatcher = require("../lib/sizewatcher");
+const config = require("../lib/config");
 const originalExit = process.exit;
 const { describe, it, beforeEach, afterEach } = require("node:test");
 const { captured, exec } = require("./capture-console");
@@ -29,11 +30,18 @@ function cleanEnvVars() {
     delete process.env.GITHUB_ACTIONS;
     delete process.env.GITHUB_BASE_REF;
     delete process.env.GITHUB_HEAD_REF;
+    delete process.env.GITHUB_REPOSITORY;
+    delete process.env.GITHUB_TOKEN;
     delete process.env.TRAVIS;
+    delete process.env.TRAVIS_PULL_REQUEST;
     delete process.env.TRAVIS_PULL_REQUEST_BRANCH;
     delete process.env.TRAVIS_BRANCH;
+    delete process.env.TRAVIS_REPO_SLUG;
     delete process.env.CIRCLECI;
     delete process.env.CIRCLE_BRANCH;
+    delete process.env.CIRCLE_PULL_REQUEST;
+    delete process.env.CIRCLE_PROJECT_USERNAME;
+    delete process.env.CIRCLE_PROJECT_REPONAME;
 }
 
 function getBeforeSha(dir=".") {
@@ -42,6 +50,16 @@ function getBeforeSha(dir=".") {
 
 function getAfterSha(dir=".") {
     return fs.readFileSync(path.join(dir, "commit.hash")).toString().trim();
+}
+
+function script(name) {
+    return path.join(PROJECT_DIR, "test/scripts", name);
+}
+
+// write a .sizewatcher.yml into the current directory (the test repo) and reload config
+function writeConfig(yaml) {
+    fs.writeFileSync(path.join(process.cwd(), ".sizewatcher.yml"), yaml);
+    config.reload();
 }
 
 // full sizewatcher runs can be longer
@@ -57,6 +75,8 @@ describe("cli e2e", function() {
         // switch into a clean new temporary directory
         const tmpDir = tmp.dirSync({unsafeCleanup: true}).name;
         process.chdir(tmpDir);
+        // no .sizewatcher.yml here => default config
+        config.reload();
 
         // track exit code
         lastExitCode = undefined;
@@ -86,13 +106,18 @@ describe("cli e2e", function() {
         assert(output.stderr.includes("Error: Not inside a git checkout"));
     }));
 
-    it("local branch no commit", TIMEOUT, captured(async (t, output) => {
-        await exec(path.join(PROJECT_DIR, "test/scripts/local-branch-no-commit.sh"));
+    it("identical branches", TIMEOUT, captured(async (t, output) => {
+        await exec(script("identical-branch.sh"));
 
-        // we simulate a local repo and run, ensure these vars from CIs are not set
-        delete process.env.GITHUB_BASE_REF;
-        delete process.env.TRAVIS_PULL_REQUEST;
-        delete process.env.TRAVIS_BRANCH;
+        await sizewatcher();
+
+        assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
+        assert(output.stdout.includes("Branches are identical, nothing to compare (main=main)."));
+        assert(!output.stdout.includes("Comparing changes"));
+    }));
+
+    it("local branch no commit", TIMEOUT, captured(async (t, output) => {
+        await exec(script("local-branch-no-commit.sh"));
 
         await sizewatcher();
 
@@ -106,12 +131,7 @@ describe("cli e2e", function() {
     }));
 
     it("local branch", TIMEOUT, captured(async (t, output) => {
-        await exec(path.join(PROJECT_DIR, "test/scripts/local-branch.sh"));
-
-        // we simulate a local repo and run, ensure these vars from CIs are not set
-        delete process.env.GITHUB_BASE_REF;
-        delete process.env.TRAVIS_PULL_REQUEST;
-        delete process.env.TRAVIS_BRANCH;
+        await exec(script("local-branch.sh"));
 
         await sizewatcher(["branch", "branch2"]);
 
@@ -125,6 +145,67 @@ describe("cli e2e", function() {
         assert(output.stdout.includes(" git:"));
         // assert(output.stdout.includes("+ ✅  git: 26.0% (173 B => 218 B)"));
         assert(output.stdout.match(/Largest files among new changes:\n\n +14B file3\n\n\nDone./));
+        // no github env vars => no reporting to github
+        assert(output.stderr.includes("Error: Cannot identify github repository."));
+    }));
+
+    it("local branch with before commit sha", TIMEOUT, captured(async (t, output) => {
+        await exec(script("local-branch.sh"));
+
+        const beforeSha = getBeforeSha("..");
+        const afterSha = getAfterSha("..");
+
+        await sizewatcher([beforeSha, "branch2"]);
+
+        assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
+        assert(output.stdout.match(new RegExp(`'${beforeSha}' \\(sha ${beforeSha}\\) => 'branch2' \\(sha ${afterSha}\\)`)));
+        assert(output.stdout.match(/Largest files among new changes:\n\n +14B file3\n\n\nDone./));
+    }));
+
+    it("local branch with size decrease", TIMEOUT, captured(async (t, output) => {
+        await exec(script("local-branch.sh"));
+        // the folder size includes the (platform dependent) directory entry size,
+        // so the relative decrease is small on some file systems: cheer for any decrease
+        writeConfig(`
+limits:
+  ok: 0%
+`);
+
+        // reverse comparison: branch2 (bigger) => branch (smaller)
+        await sizewatcher(["branch2", "branch"]);
+
+        const beforeSha = getAfterSha("..");
+        const afterSha = getBeforeSha("..");
+
+        assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
+        assert(output.stdout.match(new RegExp(`'branch2' \\(sha ${beforeSha}\\) => 'branch' \\(sha ${afterSha}\\)`)));
+        assert(output.stdout.includes("+ 🎉  git: -"));
+        // the branch commit changed "file" (7 bytes)
+        assert(output.stdout.match(/Largest files among new changes:\n\n +7B file\n\n\nDone./));
+    }));
+
+    it("local branch with default branch master", TIMEOUT, captured(async (t, output) => {
+        await exec(`${script("default-branch.sh")} master`);
+
+        await sizewatcher();
+
+        const beforeSha = getBeforeSha("..");
+        const afterSha = getAfterSha("..");
+
+        assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
+        assert(output.stdout.match(new RegExp(`'master' \\(sha ${beforeSha}\\) => 'branch' \\(sha ${afterSha}\\)`)));
+    }));
+
+    it("local branch with default branch trunk", TIMEOUT, captured(async (t, output) => {
+        await exec(`${script("default-branch.sh")} trunk`);
+
+        await sizewatcher();
+
+        const beforeSha = getBeforeSha("..");
+        const afterSha = getAfterSha("..");
+
+        assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
+        assert(output.stdout.match(new RegExp(`'trunk' \\(sha ${beforeSha}\\) => 'branch' \\(sha ${afterSha}\\)`)));
     }));
 
     it("github actions PR", TIMEOUT, captured(async (t, output) => {
@@ -133,7 +214,7 @@ describe("cli e2e", function() {
         process.env.GITHUB_BASE_REF = "main";
         process.env.GITHUB_HEAD_REF = "branch2";
 
-        await exec(path.join(PROJECT_DIR, "test/scripts/fork.sh"));
+        await exec(script("fork.sh"));
         process.chdir("checkout");
 
         await sizewatcher();
@@ -148,8 +229,20 @@ describe("cli e2e", function() {
         assert(output.stdout.match(/Largest files among new changes:\n\n +14B file3\n\n\nDone./));
     }));
 
+    it("unknown before branch", TIMEOUT, captured(async (t, output) => {
+        // checkout with a remote, so that the unknown branch is looked up in the remote
+        await exec(script("fork.sh"));
+        process.chdir("checkout");
+
+        await sizewatcher(["does-not-exist"]);
+
+        assert.strictEqual(lastExitCode, 1, `exit code should be 1 but was ${lastExitCode}`);
+        assert(output.stderr.includes("Error:"));
+        assert(output.stderr.includes("does-not-exist"));
+    }));
+
     it("no package.json in before branch", TIMEOUT, captured(async (t, output) => {
-        await exec(path.join(PROJECT_DIR, "test/scripts/no-package-json-before.sh"));
+        await exec(script("no-package-json-before.sh"));
 
         await sizewatcher();
 
@@ -160,7 +253,7 @@ describe("cli e2e", function() {
     }));
 
     it("no package.json in after branch", TIMEOUT, captured(async (t, output) => {
-        await exec(path.join(PROJECT_DIR, "test/scripts/no-package-json-after.sh"));
+        await exec(script("no-package-json-after.sh"));
 
         await sizewatcher();
 
@@ -171,7 +264,7 @@ describe("cli e2e", function() {
     }));
 
     it("package.json with dependencies removed", TIMEOUT, captured(async (t, output) => {
-        await exec(path.join(PROJECT_DIR, "test/scripts/package-json-removed.sh"));
+        await exec(script("package-json-removed.sh"));
 
         await sizewatcher();
 
@@ -182,7 +275,7 @@ describe("cli e2e", function() {
     }));
 
     it("package.json with dependencies added", TIMEOUT, captured(async (t, output) => {
-        await exec(path.join(PROJECT_DIR, "test/scripts/package-json-added.sh"));
+        await exec(script("package-json-added.sh"));
 
         await sizewatcher();
 
@@ -191,4 +284,162 @@ describe("cli e2e", function() {
         assert(output.stdout.includes("+ ❌  node_modules: 100.0%"));
         assert(output.stdout.match(/Largest files among new changes:\n\n +64B package.json\n\n/));
     }));
+
+    it("package.json with package-lock.json", TIMEOUT, captured(async (t, output) => {
+        await exec(script("npm-lockfile.sh"));
+
+        await sizewatcher();
+
+        assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
+        assert(!output.any.includes("node_modules: measurement error"));
+        assert(output.stdout.includes("  node_modules:"));
+        assert(output.stdout.includes("(no production dependencies)"));
+        // private package => no npm_package comparator
+        assert(!output.stdout.includes("npm_package:"));
+    }));
+
+    it("npm package added", TIMEOUT, captured(async (t, output) => {
+        await exec(script("npm-package.sh"));
+
+        await sizewatcher();
+
+        assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
+        assert(!output.any.includes("measurement error"));
+        assert(output.stdout.includes("+ ❌  npm_package: 100.0% (0 B => "));
+        assert(output.stdout.includes("Package contents:"));
+        assert(output.stdout.includes("package size:"));
+    }));
+
+    it("npm packages in sub directories", TIMEOUT, captured(async (t, output) => {
+        await exec(script("subdirs.sh"));
+        writeConfig(`
+comparators:
+  npm_package:
+    dir:
+      - sub1
+      - sub2
+`);
+
+        await sizewatcher();
+
+        assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
+        assert(!output.any.includes("measurement error"));
+        // sub1 grew
+        assert(output.stdout.match(/\+ .{1,2} {2}npm_package \[sub1\]: [1-9][0-9.]*% \(/), output.stdout);
+        // sub2 is unchanged
+        assert(output.stdout.includes("+ ✅  npm_package [sub2]: 0.0% ("));
+        // no npm package in the root
+        assert(!output.stdout.includes("  npm_package:"));
+    }));
+
+    it("npm package in single sub directory", TIMEOUT, captured(async (t, output) => {
+        await exec(script("subdirs.sh"));
+        writeConfig(`
+comparators:
+  npm_package:
+    dir: sub2
+`);
+
+        await sizewatcher();
+
+        assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
+        assert(output.stdout.includes("+ ✅  npm_package [sub2]: 0.0% ("));
+        assert(!output.stdout.includes("npm_package [sub1]"));
+    }));
+
+    it("disabled comparator", TIMEOUT, captured(async (t, output) => {
+        await exec(script("package-json-added.sh"));
+        writeConfig(`
+comparators:
+  node_modules: false
+`);
+
+        await sizewatcher();
+
+        assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
+        assert(output.stdout.includes("  git:"));
+        assert(!output.stdout.includes("node_modules"));
+    }));
+
+    it("absolute and byte size limits", TIMEOUT, captured(async (t, output) => {
+        await exec(script("local-branch.sh"));
+        writeConfig(`
+limits:
+  fail: 1 MB
+  warn: 20
+  ok: -1%
+`);
+
+        await sizewatcher(["branch", "branch2"]);
+
+        assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
+        // after size is a few dozen bytes: below 1 MB (fail), but above 20 bytes (warn)
+        assert(output.stdout.includes("+ ⚠️  git:"));
+    }));
+
+    describe("custom comparator", function() {
+
+        it("with build script", TIMEOUT, captured(async (t, output) => {
+            await exec(script("custom-comparator.sh"));
+            writeConfig(`
+comparators:
+  custom:
+    name: mine
+    path: "build/*.bin"
+    script: "mkdir -p build && cp size.txt build/out.bin"
+`);
+
+            await sizewatcher();
+
+            assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
+            assert(!output.any.includes("measurement error"));
+            assert(output.stdout.includes("+ ❌  mine: 150.0% (100 B => 250 B)"));
+            assert(output.stdout.match(/New size:\n\n +250 B build\/out.bin\n/), output.stdout);
+        }));
+
+        it("with multiple custom comparators", TIMEOUT, captured(async (t, output) => {
+            await exec(script("custom-comparator.sh"));
+            writeConfig(`
+comparators:
+  custom:
+    - path: "dist/*.js"
+    - name: nopath
+    - name: absolute
+      path: /tmp/does-not-matter
+`);
+
+            await sizewatcher();
+
+            assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
+            assert(!output.any.includes("measurement error"));
+            // name falls back to the path
+            assert(output.stdout.includes("+ ✅  dist/*.js: 0.0% (20 B => 20 B)"), output.stdout);
+            assert(output.stdout.match(/New size:\n\n +20 B dist\/app.js\n/), output.stdout);
+            // without path: silently skipped
+            assert(!output.stdout.includes("nopath"));
+            // absolute path: error, skipped
+            assert(output.stderr.includes("Error: custom comparator path must be relative: /tmp/does-not-matter"));
+            assert(!output.stdout.includes("absolute"));
+        }));
+
+        it("with failing script", TIMEOUT, captured(async (t, output) => {
+            await exec(script("custom-comparator.sh"));
+            writeConfig(`
+comparators:
+  custom:
+    name: boom
+    path: "build/*.bin"
+    script: "exit 1"
+`);
+
+            await sizewatcher();
+
+            // measurement errors are reported, but do not fail the run
+            assert.strictEqual(lastExitCode, undefined, `non-zero exit code: ${lastExitCode}`);
+            assert(output.stderr.includes("comparator boom failed:"));
+            assert(output.stdout.includes("+ 🚨 boom: measurement error: `exit 1` failed with exit code 1"));
+            // git comparator still ran
+            assert(output.stdout.includes("  git:"));
+        }));
+    });
 });

--- a/test/compare.test.js
+++ b/test/compare.test.js
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+'use strict';
+
+const assert = require("assert");
+const { describe, it, before, after } = require("node:test");
+const tmp = require("tmp");
+tmp.setGracefulCleanup();
+
+const config = require("../lib/config");
+const { exceeds, processDeltas } = require("../lib/compare");
+
+function delta(beforeSize, afterSize, overrides) {
+    return {
+        name: "test",
+        config: {},
+        beforeSize,
+        afterSize,
+        ...overrides
+    };
+}
+
+describe("compare", function() {
+
+    let originalCwd;
+
+    before(function() {
+        // no .sizewatcher.yml => default config (fail: 100%, warn: 30%, ok: -10%)
+        originalCwd = process.cwd();
+        process.chdir(tmp.dirSync({ unsafeCleanup: true }).name);
+        config.reload();
+    });
+
+    after(function() {
+        process.chdir(originalCwd);
+        config.reload();
+    });
+
+    describe("exceeds", function() {
+
+        it("compares percentage limits against the increase", function() {
+            assert.strictEqual(exceeds(0, 50, "50%"), true);
+            assert.strictEqual(exceeds(0, 50.1, "50%"), true);
+            assert.strictEqual(exceeds(0, 49.9, "50%"), false);
+            assert.strictEqual(exceeds(0, -10, "-10%"), true);
+            assert.strictEqual(exceeds(0, -10.1, "-10%"), false);
+        });
+
+        it("ignores whitespace around percentage limits", function() {
+            assert.strictEqual(exceeds(0, 50, " 50% "), true);
+            assert.strictEqual(exceeds(0, 49, " 50% "), false);
+        });
+
+        it("supports fractional percentage limits", function() {
+            assert.strictEqual(exceeds(0, 0.5, "0.5%"), true);
+            assert.strictEqual(exceeds(0, 0.4, "0.5%"), false);
+        });
+
+        it("compares byte string limits against the after size", function() {
+            // decimal units
+            assert.strictEqual(exceeds(10000, 0, "10 KB"), true);
+            assert.strictEqual(exceeds(9999, 0, "10 KB"), false);
+            // binary units
+            assert.strictEqual(exceeds(10240, 0, "10 KiB"), true);
+            assert.strictEqual(exceeds(10239, 0, "10 KiB"), false);
+            assert.strictEqual(exceeds(1024 * 1024, -99, "1 MiB"), true);
+            assert.strictEqual(exceeds(1000 * 1000, 0, "1 MB"), true);
+        });
+
+        it("never exceeds an unparseable string limit", function() {
+            assert.strictEqual(exceeds(Number.MAX_SAFE_INTEGER, 1000, "lots"), false);
+            assert.strictEqual(exceeds(Number.MAX_SAFE_INTEGER, 1000, ""), false);
+        });
+
+        it("compares absolute number limits against the after size", function() {
+            assert.strictEqual(exceeds(1000, 0, 1000), true);
+            assert.strictEqual(exceeds(1001, -50, 1000), true);
+            assert.strictEqual(exceeds(999, 500, 1000), false);
+        });
+    });
+
+    describe("processDeltas", function() {
+
+        it("calculates the increase percentage", function() {
+            const deltas = processDeltas([
+                delta(1000, 1500),
+                delta(1000, 500),
+                delta(1000, 1000),
+                delta(300, 400)
+            ]);
+            assert.strictEqual(deltas[0].increase, "50.0");
+            assert.strictEqual(deltas[1].increase, "-50.0");
+            assert.strictEqual(deltas[2].increase, "0.0");
+            assert.strictEqual(deltas[3].increase, "33.3");
+        });
+
+        it("handles zero sizes", function() {
+            const deltas = processDeltas([
+                delta(0, 0),
+                delta(1000, 0),
+                delta(0, 1000)
+            ]);
+            // nothing before, nothing after
+            assert.strictEqual(deltas[0].increase, "0.0");
+            assert.strictEqual(deltas[0].result, "ok");
+            // everything removed
+            assert.strictEqual(deltas[1].increase, "-100.0");
+            assert.strictEqual(deltas[1].result, "cheers");
+            // newly added: counts as 100% increase, which fails with the default 100% limit
+            assert.strictEqual(deltas[2].increase, "100.0");
+            assert.strictEqual(deltas[2].result, "fail");
+        });
+
+        it("classifies results using the default limits", function() {
+            const deltas = processDeltas([
+                delta(1000, 2000),   // +100.0% => fail
+                delta(1000, 1999),   // +99.9%  => warn
+                delta(1000, 1300),   // +30.0%  => warn
+                delta(1000, 1299),   // +29.9%  => ok
+                delta(1000, 1000),   //  0.0%   => ok
+                delta(1000, 900),    // -10.0%  => ok
+                delta(1000, 899)     // -10.1%  => cheers
+            ]);
+            assert.deepStrictEqual(deltas.map(d => d.result), ["fail", "warn", "warn", "ok", "ok", "ok", "cheers"]);
+            assert.strictEqual(deltas.summary, "fail");
+        });
+
+        it("lets comparator specific limits override the global limits", function() {
+            const deltas = processDeltas([
+                delta(1000, 1500, { config: { limits: { fail: "40%" } } }),
+                delta(1000, 1500, { config: { limits: { warn: "60%" } } }),
+                delta(1000, 1500, { config: { limits: { fail: 1400 } } }),
+                delta(1000, 1500)
+            ]);
+            assert.strictEqual(deltas[0].result, "fail");
+            assert.strictEqual(deltas[1].result, "ok");
+            assert.strictEqual(deltas[2].result, "fail");
+            assert.strictEqual(deltas[3].result, "warn");
+        });
+
+        it("counts errors and does not touch the error delta", function() {
+            const error = new Error("boom");
+            const deltas = processDeltas([
+                { name: "broken", error },
+                delta(1000, 1000)
+            ]);
+            assert.strictEqual(deltas[0].error, error);
+            assert.strictEqual(deltas[0].increase, undefined);
+            assert.strictEqual(deltas[0].result, undefined);
+            assert.strictEqual(deltas[1].result, "ok");
+            assert.strictEqual(deltas.summary, "error");
+        });
+
+        it("summarizes with precedence error > fail > warn > cheers > ok", function() {
+            assert.strictEqual(processDeltas([]).summary, "ok");
+            assert.strictEqual(processDeltas([ delta(1000, 1000) ]).summary, "ok");
+            assert.strictEqual(processDeltas([ delta(1000, 1000), delta(1000, 500) ]).summary, "cheers");
+            assert.strictEqual(processDeltas([ delta(1000, 500), delta(1000, 1400) ]).summary, "warn");
+            assert.strictEqual(processDeltas([ delta(1000, 1400), delta(1000, 3000) ]).summary, "fail");
+            assert.strictEqual(processDeltas([ delta(1000, 3000), { name: "x", error: "boom" } ]).summary, "error");
+        });
+
+        it("keeps before and after information on the deltas", function() {
+            const deltas = [ delta(1, 1) ];
+            deltas.before = { branch: "main" };
+            deltas.after = { branch: "feature" };
+            const result = processDeltas(deltas);
+            assert.strictEqual(result, deltas);
+            assert.strictEqual(result.before.branch, "main");
+            assert.strictEqual(result.after.branch, "feature");
+        });
+    });
+});

--- a/test/fake-github-api.js
+++ b/test/fake-github-api.js
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+'use strict';
+
+// Minimal fake of the GitHub REST API endpoints used by lib/github.js.
+//
+// Usage: call start() BEFORE requiring lib/github.js (it reads GITHUB_API_URL and
+// GITHUB_TOKEN at require time), then set `pulls`/`comments` per test and inspect
+// `requests` afterwards. Any fetch() to another host throws, so tests can never
+// hit the real api.github.com by accident.
+
+const http = require("http");
+
+const TOKEN = "fake-github-token";
+
+function readBody(req) {
+    return new Promise((resolve) => {
+        let data = "";
+        req.on("data", chunk => data += chunk);
+        req.on("end", () => resolve(data));
+    });
+}
+
+class FakeGithubApi {
+
+    constructor() {
+        this.reset();
+    }
+
+    reset() {
+        // recorded requests: { method, path, query, headers, body }
+        this.requests = [];
+        // canned responses
+        this.pulls = [];
+        this.comments = [];
+        this.nextCommentId = 1000;
+        // if set, the next request fails with { status, message }
+        this.failNext = null;
+    }
+
+    get token() {
+        return TOKEN;
+    }
+
+    async start() {
+        this.server = http.createServer((req, res) => this.handle(req, res));
+        await new Promise(resolve => { this.server.listen(0, "127.0.0.1", resolve); });
+        this.host = `127.0.0.1:${this.server.address().port}`;
+        this.url = `http://${this.host}`;
+
+        process.env.GITHUB_API_URL = this.url;
+        process.env.GITHUB_TOKEN = TOKEN;
+
+        // guard against real network requests
+        this.originalFetch = globalThis.fetch;
+        globalThis.fetch = (url, options) => {
+            const { host } = new URL(url);
+            if (host !== this.host) {
+                throw new Error(`unexpected network request to ${url}`);
+            }
+            return this.originalFetch(url, options);
+        };
+    }
+
+    async stop() {
+        globalThis.fetch = this.originalFetch;
+        if (this.server.closeAllConnections) {
+            this.server.closeAllConnections();
+        }
+        await new Promise(resolve => { this.server.close(resolve); });
+    }
+
+    async handle(req, res) {
+        const url = new URL(req.url, this.url);
+        const body = await readBody(req);
+        const request = {
+            method: req.method,
+            path: url.pathname,
+            query: Object.fromEntries(url.searchParams),
+            headers: req.headers,
+            body: body ? JSON.parse(body) : undefined
+        };
+        this.requests.push(request);
+
+        const send = (status, json) => {
+            res.writeHead(status, { "content-type": "application/json; charset=utf-8" });
+            res.end(JSON.stringify(json));
+        };
+
+        if (this.failNext) {
+            const { status, message } = this.failNext;
+            this.failNext = null;
+            return send(status, { message });
+        }
+
+        const route = (method, regex) => req.method === method && url.pathname.match(regex);
+
+        if (route("GET", /^\/repos\/[^/]+\/[^/]+\/pulls$/)) {
+            return send(200, this.pulls);
+        }
+        if (route("GET", /^\/repos\/[^/]+\/[^/]+\/issues\/\d+\/comments$/)) {
+            return send(200, this.comments);
+        }
+        let m;
+        if ((m = route("PATCH", /^\/repos\/([^/]+)\/([^/]+)\/issues\/comments\/(\d+)$/))) {
+            const id = Number(m[3]);
+            return send(200, {
+                id,
+                html_url: `https://github.com/${m[1]}/${m[2]}/pull/0#issuecomment-${id}`,
+                body: request.body.body
+            });
+        }
+        if ((m = route("POST", /^\/repos\/([^/]+)\/([^/]+)\/issues\/(\d+)\/comments$/))) {
+            const id = this.nextCommentId++;
+            return send(201, {
+                id,
+                html_url: `https://github.com/${m[1]}/${m[2]}/pull/${m[3]}#issuecomment-${id}`,
+                body: request.body.body
+            });
+        }
+        if (route("POST", /^\/repos\/[^/]+\/[^/]+\/statuses\/[0-9a-f]+$/)) {
+            return send(201, { id: 1, state: request.body.state });
+        }
+
+        return send(404, { message: "Not Found" });
+    }
+}
+
+module.exports = FakeGithubApi;

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -24,6 +24,8 @@ describe("github", function() {
 
     before(async function() {
         await fake.start();
+        // trailing slash (as in a documented GITHUB_API_URL example) must not break the api urls
+        process.env.GITHUB_API_URL = `${fake.url}/`;
         github = require("../lib/github");
     });
 

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+'use strict';
+
+const assert = require("assert");
+const { describe, it, before, after, beforeEach } = require("node:test");
+const FakeGithubApi = require("./fake-github-api");
+
+const fake = new FakeGithubApi();
+// loaded in before() since lib/github.js reads GITHUB_API_URL and GITHUB_TOKEN at require time
+let github;
+
+describe("github", function() {
+
+    before(async function() {
+        await fake.start();
+        github = require("../lib/github");
+    });
+
+    after(async function() {
+        await fake.stop();
+    });
+
+    beforeEach(function() {
+        fake.reset();
+    });
+
+    describe("getPullRequestForBranch", function() {
+
+        it("returns the number of the first open pull request for a branch", async function() {
+            fake.pulls = [{ number: 42 }, { number: 43 }];
+
+            const number = await github.getPullRequestForBranch("adobe", "repo", "feature");
+
+            assert.strictEqual(number, 42);
+            assert.strictEqual(fake.requests.length, 1);
+            const [req] = fake.requests;
+            assert.strictEqual(req.method, "GET");
+            assert.strictEqual(req.path, "/repos/adobe/repo/pulls");
+            assert.deepStrictEqual(req.query, {
+                head: "adobe:feature",
+                state: "open",
+                sort: "updated"
+            });
+            assert.strictEqual(req.headers.authorization, `token ${fake.token}`);
+        });
+
+        it("returns undefined if there is no pull request", async function() {
+            fake.pulls = [];
+
+            const number = await github.getPullRequestForBranch("adobe", "repo", "feature");
+
+            assert.strictEqual(number, undefined);
+            assert.strictEqual(fake.requests.length, 1);
+        });
+    });
+
+    describe("issueComment", function() {
+
+        it("creates a new comment without matcher", async function() {
+            const comment = await github.issueComment("adobe", "repo", 7, "hello");
+
+            assert.strictEqual(comment.html_url, "https://github.com/adobe/repo/pull/7#issuecomment-1000");
+            assert.strictEqual(fake.requests.length, 1);
+            const [req] = fake.requests;
+            assert.strictEqual(req.method, "POST");
+            assert.strictEqual(req.path, "/repos/adobe/repo/issues/7/comments");
+            assert.deepStrictEqual(req.body, { body: "hello" });
+            assert.strictEqual(req.headers.authorization, `token ${fake.token}`);
+        });
+
+        it("updates the first existing comment the matcher selects", async function() {
+            fake.comments = [
+                { id: 1, body: "other" },
+                { id: 2, body: "match" },
+                { id: 3, body: "match" }
+            ];
+
+            const comment = await github.issueComment("adobe", "repo", 7, "new body",
+                c => c.body === "match" ? "update" : false);
+
+            assert.strictEqual(comment.id, 2);
+            assert.strictEqual(comment.body, "new body");
+            assert.deepStrictEqual(fake.requests.map(r => `${r.method} ${r.path}`), [
+                "GET /repos/adobe/repo/issues/7/comments",
+                "PATCH /repos/adobe/repo/issues/comments/2"
+            ]);
+            assert.deepStrictEqual(fake.requests[0].query, { per_page: "100" });
+            assert.deepStrictEqual(fake.requests[1].body, { body: "new body" });
+        });
+
+        it("keeps an existing comment the matcher selects", async function() {
+            fake.comments = [
+                { id: 1, body: "other" },
+                { id: 2, body: "keep me" }
+            ];
+
+            const comment = await github.issueComment("adobe", "repo", 7, "new body",
+                c => c.body === "keep me" ? "keep" : false);
+
+            assert.strictEqual(comment.id, 2);
+            assert.strictEqual(comment.body, "keep me");
+            assert.deepStrictEqual(fake.requests.map(r => r.method), ["GET"]);
+        });
+
+        it("creates a new comment if the matcher selects none", async function() {
+            fake.comments = [
+                { id: 1, body: "other" },
+                { id: 2, body: "another" }
+            ];
+            const seen = [];
+
+            const comment = await github.issueComment("adobe", "repo", 7, "new body",
+                c => { seen.push(c.id); return false; });
+
+            assert.deepStrictEqual(seen, [1, 2]);
+            assert.strictEqual(comment.id, 1000);
+            assert.deepStrictEqual(fake.requests.map(r => r.method), ["GET", "POST"]);
+        });
+
+        it("creates a new comment if there are no comments yet", async function() {
+            const comment = await github.issueComment("adobe", "repo", 7, "new body", () => "update");
+
+            assert.strictEqual(comment.id, 1000);
+            assert.deepStrictEqual(fake.requests.map(r => r.method), ["GET", "POST"]);
+        });
+
+        it("rejects with the api error", async function() {
+            fake.failNext = { status: 403, message: "Resource not accessible by integration" };
+
+            await assert.rejects(
+                github.issueComment("adobe", "repo", 7, "hello"),
+                err => {
+                    assert.strictEqual(err.status, 403);
+                    assert.match(err.message, /Resource not accessible by integration/);
+                    return true;
+                }
+            );
+        });
+    });
+
+    describe("setCommitStatus", function() {
+
+        it("creates a commit status", async function() {
+            const sha = "0123456789abcdef0123456789abcdef01234567";
+
+            await github.setCommitStatus("adobe", "repo", sha, "failure", "Sizewatcher", "Too big", "https://example.com/comment");
+
+            assert.strictEqual(fake.requests.length, 1);
+            const [req] = fake.requests;
+            assert.strictEqual(req.method, "POST");
+            assert.strictEqual(req.path, `/repos/adobe/repo/statuses/${sha}`);
+            assert.deepStrictEqual(req.body, {
+                state: "failure",
+                context: "Sizewatcher",
+                description: "Too big",
+                target_url: "https://example.com/comment"
+            });
+        });
+
+        it("omits the target url if not set", async function() {
+            const sha = "0123456789abcdef0123456789abcdef01234567";
+
+            await github.setCommitStatus("adobe", "repo", sha, "success", "Sizewatcher", "All good");
+
+            assert.deepStrictEqual(fake.requests[0].body, {
+                state: "success",
+                context: "Sizewatcher",
+                description: "All good"
+            });
+        });
+    });
+});

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+'use strict';
+
+const assert = require("assert");
+const { describe, it, before, after } = require("node:test");
+const tmp = require("tmp");
+tmp.setGracefulCleanup();
+
+const render = require("../lib/render");
+const config = require("../lib/config");
+const { version } = require("../package.json");
+
+const BEFORE_SHA = "0123456789abcdef0123456789abcdef01234567";
+const AFTER_SHA = "89abcdef0123456789abcdef0123456789abcdef";
+
+// build a deltas array like compare() returns it
+function deltas(list, summary) {
+    const result = [...list];
+    result.before = { branch: "main", sha: BEFORE_SHA };
+    result.after = { branch: "feature", sha: AFTER_SHA };
+    if (summary !== undefined) {
+        result.summary = summary;
+    }
+    return result;
+}
+
+function delta(overrides) {
+    return {
+        name: "git",
+        result: "ok",
+        increase: "0.0",
+        beforeSize: 1000,
+        afterSize: 1000,
+        config: {},
+        ...overrides
+    };
+}
+
+describe("render", function() {
+
+    let originalCwd;
+
+    before(function() {
+        // no .sizewatcher.yml => default config
+        originalCwd = process.cwd();
+        process.chdir(tmp.dirSync({ unsafeCleanup: true }).name);
+        config.reload();
+    });
+
+    after(function() {
+        process.chdir(originalCwd);
+        config.reload();
+    });
+
+    describe("asText", function() {
+
+        it("renders header with branches and shas", function() {
+            const text = render.asText(deltas([]));
+            assert.ok(text.startsWith("Sizewatcher measured the following changes:\n\n"));
+            assert.ok(text.includes(`'main' (sha ${BEFORE_SHA}) => 'feature' (sha ${AFTER_SHA})`));
+        });
+
+        it("renders each result with icon, percentage and sizes", function() {
+            const text = render.asText(deltas([
+                delta({ name: "git", result: "ok", increase: "5.0", beforeSize: 1000, afterSize: 1050 }),
+                delta({ name: "node_modules", result: "cheers", increase: "-50.0", beforeSize: 2000, afterSize: 1000 }),
+                delta({ name: "npm_package", result: "warn", increase: "40.0", beforeSize: 1000, afterSize: 1400 }),
+                delta({ name: "custom", result: "fail", increase: "200.0", beforeSize: 1000, afterSize: 3000 })
+            ]));
+            assert.ok(text.includes("+ ✅  git: 5.0% (1 kB => 1.05 kB)\n"));
+            assert.ok(text.includes("+ 🎉  node_modules: -50.0% (2 kB => 1 kB)\n"));
+            assert.ok(text.includes("+ ⚠️  npm_package: 40.0% (1 kB => 1.4 kB)\n"));
+            assert.ok(text.includes("+ ❌  custom: 200.0% (1 kB => 3 kB)\n"));
+        });
+
+        it("renders details indented under their label", function() {
+            const text = render.asText(deltas([
+                delta({ detailsLabel: "Largest files", details: "\n10B file1\n 5B file2\n\n" })
+            ]));
+            assert.ok(text.includes("  Largest files:\n\n  10B file1\n   5B file2\n"), text);
+        });
+
+        it("does not render details section if there are no details", function() {
+            const text = render.asText(deltas([ delta({ detailsLabel: "Largest files", details: "" }) ]));
+            assert.ok(!text.includes("Largest files:"));
+        });
+
+        it("renders measurement error from Error object", function() {
+            const text = render.asText(deltas([ { name: "git", error: new Error("kaboom") } ]));
+            assert.ok(text.includes("+ 🚨 git: measurement error: kaboom\n"));
+        });
+
+        it("renders measurement error from plain string", function() {
+            const text = render.asText(deltas([ { name: "git", error: "kaboom" } ]));
+            assert.ok(text.includes("+ 🚨 git: measurement error: kaboom\n"));
+        });
+    });
+
+    describe("asMarkdown", function() {
+
+        const SUMMARIES = {
+            cheers: ["🎉", "congratulates on the size improvement 📉:", true],
+            ok: ["✅", "found no problematic size increases.", false],
+            warn: ["⚠️", "detected a size increase 📈:", true],
+            fail: ["❌", "detected a problematic size increase 📈:", true],
+            error: ["🚨", "had a measurement error:", true]
+        };
+
+        for (const [summary, [icon, text, open]] of Object.entries(SUMMARIES)) {
+            it(`renders summary '${summary}' ${open ? "expanded" : "collapsed"}`, function() {
+                const md = render.asMarkdown(deltas([], summary));
+                const firstLine = md.split("\n")[0];
+                if (open) {
+                    assert.ok(firstLine.startsWith("<details open>"), firstLine);
+                } else {
+                    assert.match(firstLine, /^<details ?>/);
+                }
+                assert.ok(firstLine.includes(`<summary>${icon} <a href="https://github.com/adobe/sizewatcher">Sizewatcher</a> ${text}</summary>`), firstLine);
+            });
+        }
+
+        it("defaults to summary 'ok' if none is set", function() {
+            const md = render.asMarkdown(deltas([]));
+            assert.match(md.split("\n")[0], /^<details ?><summary>✅ /);
+        });
+
+        it("renders increase with plus sign", function() {
+            const md = render.asMarkdown(deltas([
+                delta({ name: "git", result: "ok", increase: "0.5", beforeSize: 200, afterSize: 201 })
+            ]));
+            assert.ok(md.includes("&nbsp;&nbsp;&nbsp;✅ <code>git</code> <b>+0.5%</b> (200 B => 201 B)\n\n"), md);
+        });
+
+        it("renders decrease", function() {
+            const md = render.asMarkdown(deltas([
+                delta({ name: "git", result: "cheers", increase: "-50.0", beforeSize: 2000, afterSize: 1000 })
+            ]));
+            assert.ok(md.includes("🎉 <code>git</code> <b>-50.0%</b> (2 kB => 1 kB)"), md);
+        });
+
+        it("renders no changes for zero and near-zero increase", function() {
+            const md = render.asMarkdown(deltas([
+                delta({ name: "a", increase: "0.0", afterSize: 1000 }),
+                delta({ name: "b", increase: (-0.04).toFixed(1), afterSize: 500 }),
+                delta({ name: "c", increase: "0.09", afterSize: 200 })
+            ]));
+            assert.ok(md.includes("<code>a</code> has no changes (1 kB)"), md);
+            assert.ok(md.includes("<code>b</code> has no changes (500 B)"), md);
+            assert.ok(md.includes("<code>c</code> has no changes (200 B)"), md);
+        });
+
+        it("renders details as collapsible with newlines as <br>", function() {
+            const md = render.asMarkdown(deltas([
+                delta({ name: "git", detailsLabel: "Largest files", details: "\n10B file1\n5B file2\n" })
+            ]));
+            assert.ok(md.includes("<details><summary>✅ <code>git</code> has no changes (1 kB)</summary><br>Largest files:<pre>10B file1<br>5B file2</pre></details>\n\n"), md);
+            assert.ok(!md.includes("&nbsp;&nbsp;&nbsp;✅"));
+        });
+
+        it("renders empty details like no details", function() {
+            const md = render.asMarkdown(deltas([
+                delta({ name: "git", detailsLabel: "Largest files", details: "" })
+            ]));
+            assert.ok(md.includes("&nbsp;&nbsp;&nbsp;✅ <code>git</code>"), md);
+            assert.ok(!md.includes("Largest files"));
+        });
+
+        it("renders measurement errors", function() {
+            const md = render.asMarkdown(deltas([
+                { name: "git", error: new Error("kaboom") },
+                { name: "custom", error: "plain failure" }
+            ], "error"));
+            assert.ok(md.includes("&nbsp;&nbsp;&nbsp;🚨 <code>git</code> measurement error: kaboom\n\n"), md);
+            assert.ok(md.includes("&nbsp;&nbsp;&nbsp;🚨 <code>custom</code> measurement error: plain failure\n\n"), md);
+        });
+
+        it("renders notes with branches, version and effective configuration", function() {
+            const md = render.asMarkdown(deltas([]));
+            assert.ok(md.includes("<details><summary>Notes</summary><br>\n\n"));
+            assert.ok(md.includes(`- PR branch: \`feature\` @ ${AFTER_SHA}\n`));
+            assert.ok(md.includes(`- Base branch: \`main\` @ ${BEFORE_SHA}\n`));
+            assert.ok(md.includes(`- Sizewatcher v${version}\n`));
+            assert.ok(md.includes(`- Effective Configuration:\n\n\`\`\`yaml\n${config.asYaml()}\`\`\`\n`));
+            assert.ok(md.endsWith("</details>\n\n</blockquote></p>\n</details>\n"));
+        });
+    });
+});

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+'use strict';
+
+const assert = require("assert");
+const { describe, it, before, after, beforeEach, afterEach } = require("node:test");
+const fs = require("fs");
+const path = require("path");
+const tmp = require("tmp");
+tmp.setGracefulCleanup();
+const { captured } = require("./capture-console");
+const FakeGithubApi = require("./fake-github-api");
+const config = require("../lib/config");
+
+const fake = new FakeGithubApi();
+// lib/report.js is loaded lazily (after fake.start()) since lib/github.js reads
+// GITHUB_API_URL and GITHUB_TOKEN at require time
+function report(deltas) {
+    return require("../lib/report")(deltas);
+}
+
+const BEFORE_SHA = "0123456789abcdef0123456789abcdef01234567";
+const AFTER_SHA = "89abcdef0123456789abcdef0123456789abcdef";
+const OTHER_SHA = "ffffffffffffffffffffffffffffffffffffffff";
+
+const MARKER = `<!-- sizewatcher @ ${AFTER_SHA} -->`;
+
+function deltas(summary = "ok") {
+    const result = [{
+        name: "git",
+        result: summary === "error" ? "ok" : summary,
+        increase: "0.0",
+        beforeSize: 1000,
+        afterSize: 1000,
+        config: {}
+    }];
+    if (summary === "error") {
+        result.push({ name: "custom", error: new Error("boom") });
+    }
+    result.before = { branch: "main", sha: BEFORE_SHA };
+    result.after = { branch: "feature", sha: AFTER_SHA };
+    result.summary = summary;
+    return result;
+}
+
+// switch into a clean new temporary directory, optionally with a config file
+function mockConfig(content) {
+    const tmpDir = tmp.dirSync({ unsafeCleanup: true }).name;
+    process.chdir(tmpDir);
+    if (content !== undefined) {
+        fs.writeFileSync(path.join(tmpDir, ".sizewatcher.yml"), content);
+    }
+    config.reload();
+}
+
+function cleanEnvVars() {
+    delete process.env.GITHUB_REPOSITORY;
+    delete process.env.TRAVIS_REPO_SLUG;
+    delete process.env.CIRCLE_PROJECT_USERNAME;
+    delete process.env.CIRCLE_PROJECT_REPONAME;
+    delete process.env.TRAVIS_PULL_REQUEST;
+    delete process.env.CIRCLE_PULL_REQUEST;
+}
+
+function requestLog() {
+    return fake.requests.map(r => `${r.method} ${r.path}`);
+}
+
+describe("report", function() {
+
+    let originalCwd;
+
+    before(async function() {
+        originalCwd = process.cwd();
+        await fake.start();
+    });
+
+    after(async function() {
+        await fake.stop();
+        process.chdir(originalCwd);
+        config.reload();
+    });
+
+    beforeEach(function() {
+        cleanEnvVars();
+        fake.reset();
+        mockConfig();
+    });
+
+    afterEach(function() {
+        cleanEnvVars();
+        process.env.GITHUB_TOKEN = fake.token;
+    });
+
+    it("prints the text report", captured(async (t, output) => {
+        process.env.GITHUB_REPOSITORY = "adobe/repo";
+        process.env.TRAVIS_PULL_REQUEST = "7";
+
+        await report(deltas());
+
+        assert.ok(output.stdout.includes("Sizewatcher measured the following changes:"));
+        assert.ok(output.stdout.includes(`'main' (sha ${BEFORE_SHA}) => 'feature' (sha ${AFTER_SHA})`));
+        assert.ok(output.stdout.includes("+ ✅  git: 0.0% (1 kB => 1 kB)"));
+    }));
+
+    it("does nothing else if github comment and status are disabled", captured(async (t, output) => {
+        mockConfig(`
+report:
+  githubComment: false
+  githubStatus: false
+`);
+        process.env.GITHUB_REPOSITORY = "adobe/repo";
+        process.env.TRAVIS_PULL_REQUEST = "7";
+
+        await report(deltas());
+
+        assert.ok(output.stdout.includes("Sizewatcher measured the following changes:"));
+        assert.ok(!output.any.includes("Error"));
+        assert.deepStrictEqual(requestLog(), []);
+    }));
+
+    it("fails gracefully if the github repository cannot be identified", captured(async (t, output) => {
+        process.env.TRAVIS_PULL_REQUEST = "7";
+
+        await report(deltas());
+
+        assert.ok(output.stderr.includes("Error: Cannot identify github repository. Cannot comment on PR or update status checks in github."));
+        assert.deepStrictEqual(requestLog(), []);
+    }));
+
+    it("fails gracefully if GITHUB_TOKEN is missing", captured(async (t, output) => {
+        process.env.GITHUB_REPOSITORY = "adobe/repo";
+        process.env.TRAVIS_PULL_REQUEST = "7";
+        delete process.env.GITHUB_TOKEN;
+
+        await report(deltas());
+
+        assert.ok(output.stderr.includes("Error: Missing GITHUB_TOKEN environment variable. Cannot comment on PR or update status checks in github."));
+        assert.deepStrictEqual(requestLog(), []);
+    }));
+
+    describe("github comment", function() {
+
+        it("comments on the PR identified by github actions env vars", captured(async () => {
+            process.env.GITHUB_REPOSITORY = "adobe/repo";
+            process.env.TRAVIS_PULL_REQUEST = "7";
+
+            await report(deltas());
+
+            assert.deepStrictEqual(requestLog(), [
+                "GET /repos/adobe/repo/issues/7/comments",
+                "POST /repos/adobe/repo/issues/7/comments"
+            ]);
+            const { body } = fake.requests[1].body;
+            assert.ok(body.startsWith(`${MARKER}\n\n`), body);
+            assert.ok(body.includes("<details"), body);
+            assert.ok(body.includes("<code>git</code>"), body);
+            assert.ok(body.includes(`- PR branch: \`feature\` @ ${AFTER_SHA}`), body);
+        }));
+
+        it("uses travis repo slug and ignores TRAVIS_PULL_REQUEST=false", captured(async () => {
+            process.env.TRAVIS_REPO_SLUG = "travis/slug";
+            process.env.TRAVIS_PULL_REQUEST = "false";
+            process.env.CIRCLE_PULL_REQUEST = "https://github.com/travis/slug/pull/9";
+
+            await report(deltas());
+
+            assert.deepStrictEqual(requestLog(), [
+                "GET /repos/travis/slug/issues/9/comments",
+                "POST /repos/travis/slug/issues/9/comments"
+            ]);
+        }));
+
+        it("uses circleci project env vars and looks up the PR via the api", captured(async () => {
+            process.env.CIRCLE_PROJECT_USERNAME = "circle";
+            process.env.CIRCLE_PROJECT_REPONAME = "project";
+            fake.pulls = [{ number: 5 }];
+
+            await report(deltas());
+
+            assert.deepStrictEqual(requestLog(), [
+                "GET /repos/circle/project/pulls",
+                "GET /repos/circle/project/issues/5/comments",
+                "POST /repos/circle/project/issues/5/comments"
+            ]);
+            assert.deepStrictEqual(fake.requests[0].query, {
+                head: "circle:feature",
+                state: "open",
+                sort: "updated"
+            });
+        }));
+
+        it("fails gracefully if no PR can be found via the api", captured(async (t, output) => {
+            process.env.GITHUB_REPOSITORY = "adobe/repo";
+            fake.pulls = [];
+
+            await report(deltas());
+
+            assert.ok(output.stdout.includes("Cannot identify pull request. Cannot comment on PR."));
+            assert.deepStrictEqual(requestLog(), [
+                "GET /repos/adobe/repo/pulls"
+            ]);
+        }));
+
+        it("keeps an existing comment for the same sha", captured(async () => {
+            process.env.GITHUB_REPOSITORY = "adobe/repo";
+            process.env.TRAVIS_PULL_REQUEST = "7";
+            fake.comments = [
+                { id: 10, body: "some other comment" },
+                { id: 11, body: `${MARKER}\n\nprevious report` }
+            ];
+
+            await report(deltas());
+
+            assert.deepStrictEqual(requestLog(), [
+                "GET /repos/adobe/repo/issues/7/comments"
+            ]);
+        }));
+
+        it("updates an existing comment for a different sha", captured(async () => {
+            process.env.GITHUB_REPOSITORY = "adobe/repo";
+            process.env.TRAVIS_PULL_REQUEST = "7";
+            fake.comments = [
+                { id: 10, body: "some other comment" },
+                { id: 11, body: `<!-- sizewatcher @ ${OTHER_SHA} -->\n\nprevious report` },
+                { id: 12, body: `<!-- sizewatcher @ ${OTHER_SHA} -->\n\nduplicate report` }
+            ];
+
+            await report(deltas());
+
+            assert.deepStrictEqual(requestLog(), [
+                "GET /repos/adobe/repo/issues/7/comments",
+                "PATCH /repos/adobe/repo/issues/comments/11"
+            ]);
+            assert.ok(fake.requests[1].body.body.startsWith(MARKER));
+        }));
+
+        it("creates a new comment if existing comments are unrelated", captured(async () => {
+            process.env.GITHUB_REPOSITORY = "adobe/repo";
+            process.env.TRAVIS_PULL_REQUEST = "7";
+            fake.comments = [
+                { id: 10, body: "some other comment" },
+                { id: 11, body: "<!-- another tool @ abcdef -->" }
+            ];
+
+            await report(deltas());
+
+            assert.deepStrictEqual(requestLog(), [
+                "GET /repos/adobe/repo/issues/7/comments",
+                "POST /repos/adobe/repo/issues/7/comments"
+            ]);
+        }));
+    });
+
+    describe("github status", function() {
+
+        const STATUS_CONFIG = `
+report:
+  githubStatus: true
+`;
+
+        const EXPECTED = {
+            cheers: ["success", "Size is decreasing, perfect!"],
+            ok: ["success", "Size changes are ok."],
+            warn: ["success", "Size is increasing, but still ok."],
+            fail: ["failure", "Size increase is too high!"],
+            error: ["error", "Measurement error, see PR comment."]
+        };
+
+        for (const [summary, [state, description]] of Object.entries(EXPECTED)) {
+            it(`sets commit status '${state}' for summary '${summary}' linking to the comment`, captured(async () => {
+                mockConfig(STATUS_CONFIG);
+                process.env.GITHUB_REPOSITORY = "adobe/repo";
+                process.env.TRAVIS_PULL_REQUEST = "7";
+
+                await report(deltas(summary));
+
+                assert.deepStrictEqual(requestLog(), [
+                    "GET /repos/adobe/repo/issues/7/comments",
+                    "POST /repos/adobe/repo/issues/7/comments",
+                    `POST /repos/adobe/repo/statuses/${AFTER_SHA}`
+                ]);
+                assert.deepStrictEqual(fake.requests[2].body, {
+                    state,
+                    context: "Sizewatcher",
+                    description,
+                    target_url: "https://github.com/adobe/repo/pull/7#issuecomment-1000"
+                });
+            }));
+        }
+
+        it("sets commit status without comment if comments are disabled", captured(async () => {
+            mockConfig(`
+report:
+  githubComment: false
+  githubStatus: true
+`);
+            process.env.GITHUB_REPOSITORY = "adobe/repo";
+
+            await report(deltas("warn"));
+
+            assert.deepStrictEqual(requestLog(), [
+                `POST /repos/adobe/repo/statuses/${AFTER_SHA}`
+            ]);
+            assert.deepStrictEqual(fake.requests[0].body, {
+                state: "success",
+                context: "Sizewatcher",
+                description: "Size is increasing, but still ok."
+            });
+        }));
+    });
+});

--- a/test/scripts/custom-comparator.sh
+++ b/test/scripts/custom-comparator.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# create a repo for custom comparator tests:
+# - size.txt grows from 100 to 250 bytes in the branch (used by a custom build script)
+# - dist/app.js is identical in both branches (used by a custom path without script)
+
+# setup new git repo
+git init --initial-branch=main
+# needed for git run in CI context where none of this is set
+git config --local user.email "you@example.com"
+git config --local user.name "Your Name"
+
+awk 'BEGIN { for (i = 0; i < 100; i++) printf "a" }' > size.txt
+mkdir dist
+echo 'console.log("app");' > dist/app.js
+git add .
+git commit -a -m "initial commit"
+
+git checkout -b branch
+awk 'BEGIN { for (i = 0; i < 250; i++) printf "b" }' > size.txt
+git commit -a -m "grow size.txt"

--- a/test/scripts/default-branch.sh
+++ b/test/scripts/default-branch.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
-# checkout local branch but without remote branch
+# repo with a custom default branch name (given as first argument, e.g. master or trunk)
+# and a feature branch checked out, no remote
 
 # setup new git repo
-git init --initial-branch=main
+git init --initial-branch=$1
 # needed for git run in CI context where none of this is set
 git config --local user.email "you@example.com"
 git config --local user.name "Your Name"
@@ -11,26 +12,12 @@ git config --local user.name "Your Name"
 echo "hello" > file
 git add file
 git commit -a -m "initial commit"
-echo "hello" > file2
-git add .
-git commit -a -m "change 2"
-
-git checkout -b branch
-echo "hello2" > file
-git add file
-git commit -a -m "branch commit"
 
 git rev-parse HEAD > ../before.hash
 
-git checkout main
-
-git checkout -b branch2
-echo "another hello" > file3
-git add file3
-git commit -a -m "branch commit 2"
+git checkout -b branch
+echo "hello2" > file
+git commit -a -m "branch commit"
 
 # need the commit hash in the js code, and it's different each run
 git rev-parse HEAD > ../commit.hash
-
-# leave HEAD on main so that neither branch nor branch2 is the current branch
-git checkout main

--- a/test/scripts/identical-branch.sh
+++ b/test/scripts/identical-branch.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# single main branch, nothing else to compare against
+
+# setup new git repo
+git init --initial-branch=main
+# needed for git run in CI context where none of this is set
+git config --local user.email "you@example.com"
+git config --local user.name "Your Name"
+
+echo "hello" > file
+git add file
+git commit -a -m "initial commit"

--- a/test/scripts/npm-lockfile.sh
+++ b/test/scripts/npm-lockfile.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# create a repo where a package.json with a package-lock.json (but no dependencies) is added in a branch
+
+# setup new git repo
+git init --initial-branch=main
+# needed for git run in CI context where none of this is set
+git config --local user.email "you@example.com"
+git config --local user.name "Your Name"
+
+echo "hello" > file
+git add file
+git commit -a -m "initial commit"
+
+# add package.json and lockfile in new branch
+git checkout -b branch
+echo '{ "name": "test-project", "version": "1.0.0", "private": true }' > package.json
+cat > package-lock.json <<EOF
+{
+  "name": "test-project",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "test-project",
+      "version": "1.0.0"
+    }
+  }
+}
+EOF
+git add package.json package-lock.json
+git commit -a -m "add package.json and package-lock.json"

--- a/test/scripts/npm-package.sh
+++ b/test/scripts/npm-package.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# create a repo where a publishable package.json (with version) is added in a branch
+
+# setup new git repo
+git init --initial-branch=main
+# needed for git run in CI context where none of this is set
+git config --local user.email "you@example.com"
+git config --local user.name "Your Name"
+
+echo "hello" > file
+git add file
+git commit -a -m "initial commit"
+
+# add package.json in new branch
+git checkout -b branch
+echo '{ "name": "test-project", "version": "1.0.0" }' > package.json
+git add package.json
+git commit -a -m "add package.json"

--- a/test/scripts/subdirs.sh
+++ b/test/scripts/subdirs.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# create a repo with two npm packages in sub directories, one of them growing in a branch
+
+# setup new git repo
+git init --initial-branch=main
+# needed for git run in CI context where none of this is set
+git config --local user.email "you@example.com"
+git config --local user.name "Your Name"
+
+mkdir sub1 sub2
+echo '{ "name": "sub1", "version": "1.0.0" }' > sub1/package.json
+echo 'console.log("sub1");' > sub1/index.js
+echo '{ "name": "sub2", "version": "1.0.0" }' > sub2/package.json
+echo 'console.log("sub2");' > sub2/index.js
+git add .
+git commit -a -m "initial commit"
+
+# grow sub1 in new branch
+git checkout -b branch
+echo 'console.log("some more code in sub1 to make the package bigger");' > sub1/extra.js
+git add .
+git commit -a -m "add extra.js to sub1"

--- a/test/size.test.js
+++ b/test/size.test.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+'use strict';
+
+const assert = require("assert");
+const { describe, it, before } = require("node:test");
+const fs = require("fs");
+const path = require("path");
+const tmp = require("tmp");
+tmp.setGracefulCleanup();
+
+const { getFileSize, getFolderRegex } = require("../lib/size");
+
+describe("size", function() {
+
+    let dir;
+
+    before(function() {
+        dir = tmp.dirSync({ unsafeCleanup: true }).name;
+        fs.writeFileSync(path.join(dir, "a.txt"), "a".repeat(100));
+        fs.mkdirSync(path.join(dir, "sub"));
+        fs.writeFileSync(path.join(dir, "sub", "b.txt"), "b".repeat(200));
+        fs.mkdirSync(path.join(dir, "sub", "deeper"));
+        fs.writeFileSync(path.join(dir, "sub", "deeper", "c.txt"), "c".repeat(300));
+        // sibling with same prefix as "sub"
+        fs.mkdirSync(path.join(dir, "subfolder"));
+        fs.writeFileSync(path.join(dir, "subfolder", "d.txt"), "d".repeat(400));
+    });
+
+    describe("getFileSize", function() {
+
+        it("returns the size of a single file", async function() {
+            assert.strictEqual(await getFileSize(path.join(dir, "a.txt")), 100);
+        });
+
+        it("returns the total size of a folder including nested files", async function() {
+            const total = await getFileSize(dir);
+            // directories themselves have a platform dependent size, files are exact
+            assert.ok(total >= 100 + 200 + 300 + 400, `total ${total} too small`);
+        });
+
+        it("ignores matching paths", async function() {
+            const total = await getFileSize(dir);
+            const withoutSub = await getFileSize(dir, { ignore: getFolderRegex(path.join(dir, "sub")) });
+            const subSize = await getFileSize(path.join(dir, "sub"));
+            assert.strictEqual(withoutSub, total - subSize);
+            // sibling "subfolder" is not ignored
+            assert.ok(withoutSub >= 100 + 400);
+        });
+
+        it("returns 0 for a nonexistent path", async function() {
+            assert.strictEqual(await getFileSize(path.join(dir, "does-not-exist")), 0);
+        });
+    });
+
+    describe("getFolderRegex", function() {
+
+        it("matches the folder itself and all descendants", function() {
+            const regex = getFolderRegex("/repo/.git");
+            assert.ok(regex.test("/repo/.git"));
+            assert.ok(regex.test("/repo/.git/HEAD"));
+            assert.ok(regex.test("/repo/.git/objects/ab/cdef"));
+        });
+
+        it("does not match siblings with the same prefix or same name elsewhere", function() {
+            const regex = getFolderRegex("/repo/.git");
+            assert.ok(!regex.test("/repo/.github"));
+            assert.ok(!regex.test("/repo/.gitignore"));
+            assert.ok(!regex.test("/repo/.github/workflows/ci.yml"));
+            assert.ok(!regex.test("/other/.git"));
+            assert.ok(!regex.test("/repo/sub/.git"));
+        });
+
+        it("escapes regex special characters in the path", function() {
+            const regex = getFolderRegex("/tmp/build (1)+v1.0/[out]");
+            assert.ok(regex.test("/tmp/build (1)+v1.0/[out]"));
+            assert.ok(regex.test("/tmp/build (1)+v1.0/[out]/file"));
+            assert.ok(!regex.test("/tmp/build 1+v1x0/out"));
+            assert.ok(!regex.test("/tmp/build (1)+v1.0/o"));
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Unit tests for `render`, `compare` (limits and result classification), `size`, `github` (against a local fake GitHub API server) and `report`
- New e2e cases for the checkout logic (identical branches, `master`/`trunk` default branches, before given as commit sha, unknown branch, Travis PR and branch builds), custom comparators (build script, multiple entries, absolute path, failing script), `npm_package` incl. the `dir` option, `package-lock.json` (`npm ci`) and configured limits
- The e2e tests clear all GitHub, Travis and CircleCI env vars, so they can never reach the real GitHub API when run in CI with a token

Coverage (c8, lines): 73% -> 99.55%. All `lib/` files are at 100% except `comparators/custom.js` (98%) and `comparators/node_modules.js` (96%); the rest is environment dependent (`howfat` output) or unreachable.

## Small lib changes

- `compare.js` and `report.js` read the config lazily via `config.get()` so tests can reload it; `compare.js` exposes `exceeds()` and `processDeltas()` for unit tests
- Removed unused `getFileRegex()` from `size.js`

## Bug fixes found on the way

- A measurement error (`summary: error`) set a green `success` commit status without description; it now sets an `error` status with a description
- Fractional percentage limits such as `0.5%` were truncated to integers
- A `GITHUB_API_URL` with a trailing slash (as previously shown in the README) resulted in invalid `//repos/...` API urls

## Follow-ups noticed but not changed here

- Real Travis PR builds would fail in `checkout.js` when fetching the after branch into the before clone, because the shallow CI clone lacks the branch ref
- A failed PR comment (e.g. 403 on fork PRs) exits 1 after the text report was already printed
- `checkout.js` clones the after dir with the raw cli argument rather than the resolved after branch
- `listComments` is not paginated (more than 100 comments would create a duplicate report comment)

## Test plan

- [x] `npm run lint` clean
- [x] `npm test`: 106 tests pass
- [x] `npm run coverage`: 99.55% lines
- [x] `npm test` with `GITHUB_REPOSITORY`, `GITHUB_TOKEN`, `GITHUB_API_URL` and `CIRCLE_PULL_REQUEST` exported (simulating CI) still passes without network access to GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)
